### PR TITLE
Add dill to peer image 

### DIFF
--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -106,6 +106,7 @@ RUN apt-get update \
         python \
         python-dev \
         python-numpy \
+        python-dill \
     && rm -rf /var/lib/apt/lists/* \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 50 --slave /usr/bin/g++ g++ /usr/bin/g++-5 \
     && wget --progress=dot:giga https://github.com/downloads/PMBio/peer/peer_source_1.3.tar.gz \


### PR DESCRIPTION
To allow this image to be used as a Hail batch python_job