### PR TITLE
Add validation tools

### DIFF
--- a/images/validation/Dockerfile
+++ b/images/validation/Dockerfile
@@ -1,0 +1,16 @@
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/hap.py:v0.3.9
+
+ENV TZ=Australia
+
+RUN apt-get update && \
+    apt-get install -y unzip && \
+    apt-get clean -y
+
+
+# Install VcfEval
+RUN wget https://github.com/RealTimeGenomics/rtg-tools/releases/download/3.12.1/rtg-tools-3.12.1-linux-x64.zip && \
+    unzip rtg-tools-3.12.1-linux-x64.zip && \
+    rm rtg-tools-3.12.1-linux-x64.zip && \
+    mv rtg-tools-3.12.1 /vcfeval
+
+ENV PATH="/opt/hap.py/bin:$PATH" VCFEVAL_JAR="/vcfeval/RTG.jar"

--- a/images/validation/Dockerfile
+++ b/images/validation/Dockerfile
@@ -1,11 +1,9 @@
-FROM australia-southeast1-docker.pkg.dev/cpg-common/images/hap.py:v0.3.9
+FROM pkrusche/hap.py:v0.3.9
 
-ENV TZ=Australia
-
+# requires unzip
 RUN apt-get update && \
     apt-get install -y unzip && \
     apt-get clean -y
-
 
 # Install VcfEval
 RUN wget https://github.com/RealTimeGenomics/rtg-tools/releases/download/3.12.1/rtg-tools-3.12.1-linux-x64.zip && \

--- a/scripts/move-hap.py:v0.3.9.sh
+++ b/scripts/move-hap.py:v0.3.9.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+
+gcloud auth configure-docker australia-southeast1-docker.pkg.dev
+skopeo copy docker://docker.io/pkrusche/hap.py:v0.3.9 docker://australia-southeast1-docker.pkg.dev/cpg-common/images/hap.py:v0.3.9


### PR DESCRIPTION
Adds a skopeo script to copy the latest version of the hap.py docker image into the CPG registry

Adds a Dockerfile to build the RTGtools (`vcfeval`) into that same image, using the standalone jar file from https://www.realtimegenomics.com/products/rtg-tools