### PR TITLE
remove flanking braces for env vars

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: "build image"
         run: |
-          docker build --tag $DOCKER_IMAGE images/$IMAGE_NAME/ --build-arg VERSION=$IMAGE_NAME
+          docker build --tag $DOCKER_IMAGE images/$IMAGE_NAME/ --build-arg VERSION=$IMAGE_TAG
 
       - name: "push image"
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: "build image"
         run: |
-          docker build --tag $DOCKER_IMAGE images/${IMAGE_NAME}/ --build-arg VERSION=${IMAGE_TAG}
+          docker build --tag $DOCKER_IMAGE images/$IMAGE_NAME/ --build-arg VERSION=$IMAGE_NAME
 
       - name: "push image"
         run: |


### PR DESCRIPTION
I assumed that the syntax for a github workflow would be wrapping in ${braces}, but the arguments were passed as:

```Run docker build --tag $DOCKER_IMAGE images/$***IMAGE_NAME***/ --build-arg VERSION=$***IMAGE_TAG***```

Based on syntax from the documentation:

```
If you need to use a workflow run's URL from within a job, you can combine these environment variables: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
```

There is no brace protection required for a path featuring values between slashes