### PR TITLE
no braces, slight tweak to arg passing

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: "build image"
         run: |
-          docker build --tag $DOCKER_IMAGE images/$IMAGE_NAME/ --build-arg VERSION=$IMAGE_NAME
+          docker build --tag $DOCKER_IMAGE images/$IMAGE_NAME/ --build-arg VERSION=$IMAGE_TAG
 
       - name: "push image"
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: "build image"
         run: |
-          docker build --tag $DOCKER_IMAGE images/$IMAGE_NAME/ --build-arg VERSION=$IMAGE_TAG
+          docker build --tag $DOCKER_IMAGE images/$IMAGE_NAME/ --build-arg VERSION=$IMAGE_NAME
 
       - name: "push image"
         run: |

--- a/images/hap.py/Dockerfile
+++ b/images/hap.py/Dockerfile
@@ -1,4 +1,3 @@
-ARG VERSION=${VERSION:-v0.3.15}
 FROM ubuntu:18.04
 
 # installation from https://github.com/Illumina/hap.py/blob/master/Dockerfile
@@ -43,7 +42,7 @@ RUN wget http://archive.apache.org/dist/ant/binaries/apache-ant-1.9.7-bin.tar.gz
 ENV PATH="$PATH:/opt/apache-ant-1.9.7/bin"
 
 # clone in, install, delete
-RUN git clone --depth 1 --branch $VERSION https://github.com/Illumina/hap.py /opt/hap.py-source && \
+RUN git clone --depth 1 --branch v0.3.15 https://github.com/Illumina/hap.py /opt/hap.py-source && \
 	python /opt/hap.py-source/install.py /opt/hap.py --with-rtgtools --no-tests && \
 	rm -rf /opt/hap.py-source
 

--- a/images/hap.py/Dockerfile
+++ b/images/hap.py/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
 
+ARG VERSION=${VERSION:-v0.3.15}
+
 # installation from https://github.com/Illumina/hap.py/blob/master/Dockerfile
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -42,7 +44,7 @@ RUN wget http://archive.apache.org/dist/ant/binaries/apache-ant-1.9.7-bin.tar.gz
 ENV PATH="$PATH:/opt/apache-ant-1.9.7/bin"
 
 # clone in, install, delete
-RUN git clone --depth 1 --branch v0.3.15 https://github.com/Illumina/hap.py /opt/hap.py-source && \
+RUN git clone --depth 1 --branch ${VERSION} https://github.com/Illumina/hap.py /opt/hap.py-source && \
 	python /opt/hap.py-source/install.py /opt/hap.py --with-rtgtools --no-tests && \
 	rm -rf /opt/hap.py-source
 

--- a/images/hap.py/Dockerfile
+++ b/images/hap.py/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=0.3.15
+ARG VERSION=${VERSION:-v0.3.15}
 FROM ubuntu:18.04
 
 # installation from https://github.com/Illumina/hap.py/blob/master/Dockerfile
@@ -40,10 +40,10 @@ WORKDIR /opt
 RUN wget http://archive.apache.org/dist/ant/binaries/apache-ant-1.9.7-bin.tar.gz && \
     tar xzf apache-ant-1.9.7-bin.tar.gz && \
     rm apache-ant-1.9.7-bin.tar.gz
-ENV PATH $PATH:/opt/apache-ant-1.9.7/bin
+ENV PATH="$PATH:/opt/apache-ant-1.9.7/bin"
 
 # clone in, install, delete
-RUN git clone --depth 1 --branch v${VERSION} https://github.com/Illumina/hap.py /opt/hap.py-source && \
+RUN git clone --depth 1 --branch $VERSION https://github.com/Illumina/hap.py /opt/hap.py-source && \
 	python /opt/hap.py-source/install.py /opt/hap.py --with-rtgtools --no-tests && \
 	rm -rf /opt/hap.py-source
 

--- a/images/hap.py/Dockerfile
+++ b/images/hap.py/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 ARG VERSION=${VERSION:-v0.3.15}
 
@@ -44,7 +44,7 @@ RUN wget http://archive.apache.org/dist/ant/binaries/apache-ant-1.9.7-bin.tar.gz
 ENV PATH="$PATH:/opt/apache-ant-1.9.7/bin"
 
 # clone in, install, delete
-RUN git clone --depth 1 --branch ${VERSION} https://github.com/Illumina/hap.py /opt/hap.py-source && \
+RUN git clone --depth 1 --single-branch --branch ${VERSION} https://github.com/Illumina/hap.py /opt/hap.py-source && \
 	python /opt/hap.py-source/install.py /opt/hap.py --with-rtgtools --no-tests && \
 	rm -rf /opt/hap.py-source
 


### PR DESCRIPTION
The variable expansion for `${VERSION}` inside the docker build is still coming out as `***VERSION***` instead of 0.3.15, even though the Docker instructions suggest this should be passed correctly:

see https://github.com/populationgenomics/images/runs/7721337852?check_suite_focus=true

https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact

```
docker build --tag $DOCKER_IMAGE images/$IMAGE_NAME/ --build-arg VERSION=$IMAGE_TAG
  shell: /usr/bin/bash -e ***0***
  env:
    DOCKER_BUILDKIT: 1
    BUILDKIT_PROGRESS: plain
    CLOUDSDK_CORE_DISABLE_PROMPTS: 1
    DOCKER_IMAGE: australia-southeast1-docker.pkg.dev/cpg-common/images/hap.py
    IMAGE_NAME: hap.py
    IMAGE_TAG: 0.3.15
```

I think there's something I'm not seeing here, so I'd really welcome eyes/improvements!