### PR TITLE
Revert to earlier ubuntu for python2

### DIFF
--- a/images/hap.py/Dockerfile
+++ b/images/hap.py/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:18.04
 
 ARG VERSION=${VERSION:-v0.3.15}
 


### PR DESCRIPTION
Finally managed to build this locally! I've tested that `hap.py` and `pre.py` are both in $PATH, and the env variable $RTG_JAR is set and functional

Confirmed with the Hap.py codebase that the python version supported is <=2.7.3, so we need an install environment for python2. As a result I've reverted the base image Ubuntu 22.04 -> 18.04.

It did get stuck on the Hap.py/RTG install during my first local attempt, then on a retry it built smoothly (one to watch on the deploy pipeline)