### PR TITLE
Update sam and bcftools

### DIFF
--- a/images/hap.py/Dockerfile
+++ b/images/hap.py/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 ARG VERSION=${VERSION:-v0.3.15}
-ARG HTS_VERSION=1.15.1
+ARG HTS_VERSION==${HTSVERSION:-1.15.1}
 
 # installation from https://github.com/Illumina/hap.py/blob/master/Dockerfile
 ENV DEBIAN_FRONTEND=noninteractive

--- a/images/hap.py/Dockerfile
+++ b/images/hap.py/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 
 ARG VERSION=${VERSION:-v0.3.15}
+ARG HTS_VERSION=1.15.1
 
 # installation from https://github.com/Illumina/hap.py/blob/master/Dockerfile
 ENV DEBIAN_FRONTEND=noninteractive
@@ -15,6 +16,7 @@ RUN apt-get update && \
         cython \
         git \
         libbz2-dev \
+        liblzma-dev \
         libncurses5-dev \
         openjdk-8-jdk \
         pkg-config \
@@ -44,10 +46,26 @@ RUN wget -q http://archive.apache.org/dist/ant/binaries/apache-ant-1.9.7-bin.tar
     rm apache-ant-1.9.7-bin.tar.gz
 ENV PATH="$PATH:/opt/apache-ant-1.9.7/bin"
 
-# clone in, install, delete
+# clone in, install, delete - then update bcftools/samtools
 RUN git clone --depth 1 --single-branch --branch ${VERSION} https://github.com/Illumina/hap.py /opt/hap.py-source && \
 	python /opt/hap.py-source/install.py /opt/hap.py --with-rtgtools --no-tests && \
-	rm -rf /opt/hap.py-source
+	rm -rf /opt/hap.py-source && \
+	wget https://github.com/samtools/bcftools/releases/download/${HTS_VERSION}/bcftools-${HTS_VERSION}.tar.bz2 && \
+	tar -xf bcftools-${HTS_VERSION}.tar.bz2 && \
+	cd bcftools-${HTS_VERSION} && \
+	bash configure --prefix=/opt/hap.py && \
+	make && \
+	make install && \
+	cd .. && \
+	rm -rf bcftools-${HTS_VERSION}.tar.bz2 bcftools-${HTS_VERSION} && \
+	wget https://github.com/samtools/samtools/releases/download/${HTS_VERSION}/samtools-${HTS_VERSION}.tar.bz2 && \
+	tar -xf samtools-${HTS_VERSION}.tar.bz2 && \
+	cd samtools-${HTS_VERSION} && \
+	bash configure --prefix=/opt/hap.py && \
+	make && \
+	make install && \
+	cd .. && \
+	rm -rf samtools-${HTS_VERSION}.tar.bz2 samtools-${HTS_VERSION}
 
 ENV PATH="/opt/hap.py/bin:$PATH"
 ENV RTG_JAR="/opt/hap.py/libexec/rtg-tools-install/RTG.jar"

--- a/images/hap.py/Dockerfile
+++ b/images/hap.py/Dockerfile
@@ -47,10 +47,11 @@ RUN wget -q http://archive.apache.org/dist/ant/binaries/apache-ant-1.9.7-bin.tar
 ENV PATH="$PATH:/opt/apache-ant-1.9.7/bin"
 
 # clone in, install, delete - then update bcftools/samtools
+# hadolint ignore=DL3003
 RUN git clone --depth 1 --single-branch --branch ${VERSION} https://github.com/Illumina/hap.py /opt/hap.py-source && \
 	python /opt/hap.py-source/install.py /opt/hap.py --with-rtgtools --no-tests && \
 	rm -rf /opt/hap.py-source && \
-	wget https://github.com/samtools/bcftools/releases/download/${HTS_VERSION}/bcftools-${HTS_VERSION}.tar.bz2 && \
+	wget -q https://github.com/samtools/bcftools/releases/download/${HTS_VERSION}/bcftools-${HTS_VERSION}.tar.bz2 && \
 	tar -xf bcftools-${HTS_VERSION}.tar.bz2 && \
 	cd bcftools-${HTS_VERSION} && \
 	bash configure --prefix=/opt/hap.py && \
@@ -58,7 +59,7 @@ RUN git clone --depth 1 --single-branch --branch ${VERSION} https://github.com/I
 	make install && \
 	cd .. && \
 	rm -rf bcftools-${HTS_VERSION}.tar.bz2 bcftools-${HTS_VERSION} && \
-	wget https://github.com/samtools/samtools/releases/download/${HTS_VERSION}/samtools-${HTS_VERSION}.tar.bz2 && \
+	wget -q https://github.com/samtools/samtools/releases/download/${HTS_VERSION}/samtools-${HTS_VERSION}.tar.bz2 && \
 	tar -xf samtools-${HTS_VERSION}.tar.bz2 && \
 	cd samtools-${HTS_VERSION} && \
 	bash configure --prefix=/opt/hap.py && \


### PR DESCRIPTION
The latest change of the hap.py image was to bring the hap.py codebase up to date (inc. the bundled version of RTG tools)

This has not updated the SAM/BCFtools versions which are included, currently 1.4.1 (2017)

This tweak to the build file updates the versions of both tools to 1.15.1, and adds a configurable build hts_version argument to update again in future

Tested on a local build - bcftools and samtools are both distributed with an internal HTSlib that they are compiled with, so this should not have any downstream implications

There is at least one command for Hap.py that uses a deprecated argument, but BCFtools transparently changes this to the correct form and issues a warning