### PR TITLE
updates the loftee plugin

### DIFF
--- a/images/vep/Dockerfile
+++ b/images/vep/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch-slim
 
 ENV MAMBA_ROOT_PREFIX=/root/micromamba
 ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
-ARG VERSION=${VERSION:-104.3}
+ARG VERSION=${VERSION:-105.0}
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
@@ -26,3 +26,7 @@ RUN export GCSFUSE_REPO=gcsfuse-$(lsb_release -c -s) && \
     echo "deb http://packages.cloud.google.com/apt $GCSFUSE_REPO main" | tee /etc/apt/sources.list.d/gcsfuse.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     apt-get update && apt-get install -y gcsfuse
+
+RUN git clone -b grch38 https://github.com/konradjk/loftee.git && \
+    cp -r loftee/* $MAMBA_ROOT_PREFIX/share/ensembl-vep-${VERSION}* \
+    && rm -rf loftee

--- a/images/vep/Dockerfile
+++ b/images/vep/Dockerfile
@@ -23,18 +23,21 @@ RUN apt-get update && \
     micromamba install -y --prefix $MAMBA_ROOT_PREFIX -c bioconda -c conda-forge \
     ensembl-vep=${VERSION} \
     # Loftee deps:
-    samtools perl-list-moreutils perl-dbd-sqlite \
-    google-cloud-sdk && \
+    perl-dbd-sqlite \
+    perl-list-moreutils \
+    samtools \
+    google-cloud-sdk \
+    && \
     rm -r /root/micromamba/pkgs
 
 # Install Bio::Perl for Loftee (conda's perl-bioperl doesn't work)
 RUN vep_install --AUTO a --NO_HTSLIB
 
-# Install gcsfuse to mount VEP cache fiels
-RUN export GCSFUSE_REPO=gcsfuse-$(lsb_release -c -s) && \
+# Install gcsfuse to mount VEP cache files
+RUN GCSFUSE_REPO=gcsfuse-$(lsb_release -c -s) && \
     echo "deb http://packages.cloud.google.com/apt $GCSFUSE_REPO main" | tee /etc/apt/sources.list.d/gcsfuse.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update && apt-get install -y gcsfuse
+    apt-get update && apt-get install --no-install-recommends -y gcsfuse
 
 RUN git clone -b grch38 https://github.com/konradjk/loftee.git && \
     cp -r loftee/* $MAMBA_ROOT_PREFIX/share/ensembl-vep-${VERSION}* \

--- a/images/vep/Dockerfile
+++ b/images/vep/Dockerfile
@@ -6,7 +6,16 @@ ARG VERSION=${VERSION:-105.0}
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
-    apt-get install -y git wget bash bzip2 zip lsb-release curl gnupg2 && \
+    apt-get install --no-install-recommends -y \
+    bash \
+    bzip2 \
+    curl \
+    git \
+    gnupg2 \
+    lsb-release \
+    wget \
+    zip \
+    && \
     rm -r /var/lib/apt/lists/* && \
     rm -r /var/cache/apt/* && \
     wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \


### PR DESCRIPTION
The `main` branch of loftee causes a ton of error logging messages when running on GRCh38.
Example [here](https://batch.hail.populationgenomics.org.au/batches/378307/jobs/17)  (similar errors being throw 27000+ times during processing of one variant subset)

There is a separate branch which we can use instead, with an updated version of the plugin files, see https://github.com/konradjk/loftee/issues/84 (and other similar issues)

The path to copy the plugin files to contains a `*` - 

 -  for VEP 105.0, the path is /root/micromamba/share/ensembl-vep-105.0-1
 - for 107.0 this is /root/micromamba/share/ensembl-vep-107.0-0

This copy works for both situations when building the image, but doesn't resolve hard-coding like [this](https://github.com/populationgenomics/production-pipelines/blob/main/jobs/vep.py#L194)

As of today I don't believe there's a way to set an env variable to the result of a RUN command, otherwise this could be used:

`ls -l ${MAMBA_ROOT_PREFIX}/share/ | grep ensembl | awk '{ print $9}'`

this could be used in setting the path in the production-pipelines job?

```
LOFTEE_PLUGIN_PATH="${MAMBA_ROOT_PREFIX}/share/$(ls -l ${MAMBA_ROOT_PREFIX}/share/ | grep ensembl | awk '{ print $9 }')"
```

... but this looks really heavy handed