### PR TITLE
add gcloud to stripy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,10 +22,10 @@ repos:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-      rev: '5.0.4'    
-      hooks:
-        - id: flake8
-          additional_dependencies: [flake8-bugbear, flake8-quotes]
+    rev: '5.0.4'
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-bugbear, flake8-quotes]
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,9 +22,10 @@ repos:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-      rev: '5.0.4'    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-bugbear, flake8-quotes]
+      rev: '5.0.4'    
+      hooks:
+        - id: flake8
+          additional_dependencies: [flake8-bugbear, flake8-quotes]
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,9 +21,8 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: "3.8.4"
-    hooks:
+  - repo: https://github.com/PyCQA/flake8
+      rev: '5.0.4'    hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear, flake8-quotes]
 

--- a/images/stripy/Dockerfile
+++ b/images/stripy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL \
   version="v2.2" \
@@ -34,7 +34,11 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     zlib1g-dev 
 
 ## Install Google cloud-sdk
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-cli -y
+RUN curl https://sdk.cloud.google.com > install.sh && \
+    bash install.sh --disable-prompts --install-dir=/opt && \
+    rm install.sh
+
+ENV PATH=$PATH:/opt/google-cloud-sdk/bin
 
 WORKDIR /usr/local/bin/
 
@@ -68,8 +72,7 @@ RUN wget https://github.com/Illumina/REViewer/releases/download/${REVIEWER_VERSI
     && ln -s /usr/local/bin/REViewer /usr/bin/REViewer
 
 # Install STRipy by cloning from git repo (the most updated version)
-RUN which python3 && python3 --version && \
-git clone https://gitlab.com/andreassh/stripy-pipeline.git \
+RUN git clone https://gitlab.com/andreassh/stripy-pipeline.git \
     && chmod 755 stripy-pipeline/batch.sh \
     && python3 -m pip install -r stripy-pipeline/requirements.txt
 

--- a/images/stripy/Dockerfile
+++ b/images/stripy/Dockerfile
@@ -9,12 +9,15 @@ ENV TZ=Europe/London
 
 # Run update and install necessary libraries, including BWA and python3
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    apt-transport-https \
     build-essential \
     bwa \
     bzip2 \
     ca-certificates \
+    curl \
     gcc \
     git \
+    gnupg \
     gpg-agent \
     libbz2-dev \
     libcurl4-openssl-dev \
@@ -28,7 +31,10 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     python3-pip \
     software-properties-common \
     wget \
-    zlib1g-dev
+    zlib1g-dev 
+
+## Install Google cloud-sdk
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-cli -y
 
 WORKDIR /usr/local/bin/
 
@@ -62,7 +68,8 @@ RUN wget https://github.com/Illumina/REViewer/releases/download/${REVIEWER_VERSI
     && ln -s /usr/local/bin/REViewer /usr/bin/REViewer
 
 # Install STRipy by cloning from git repo (the most updated version)
-RUN git clone https://gitlab.com/andreassh/stripy-pipeline.git \
+RUN which python3 && python3 --version && \
+git clone https://gitlab.com/andreassh/stripy-pipeline.git \
     && chmod 755 stripy-pipeline/batch.sh \
     && python3 -m pip install -r stripy-pipeline/requirements.txt
 


### PR DESCRIPTION
Add the gcloud sdk to the stripy image. For right or wrong, I have done this install as per google's instructions not the conda aproach cpg seems to typically use. 