### PR TITLE
Install DRAGMAP from conda instead of installing from source

### DIFF
--- a/images.toml
+++ b/images.toml
@@ -2,6 +2,7 @@
 bcftools = '1.16'
 bedtools = '2.30.0'
 cellregmap = '0.0.3'
+dragmap = '1.3.0'
 expansionhunter = '5.0.0'
 fastqc = '0.11.9'
 gatk = '4.2.6.1'

--- a/images/dragmap/Dockerfile
+++ b/images/dragmap/Dockerfile
@@ -1,29 +1,15 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ENV MAMBA_ROOT_PREFIX /root/micromamba
 ENV PATH $MAMBA_ROOT_PREFIX/bin:$PATH
 ARG VERSION=${VERSION:-1.3.0}
 
-RUN apt-get update && apt-get install -y \
-    git wget bash bzip2 zip \
-    build-essential libboost-all-dev \
-    && \
+RUN apt-get update && \
+    apt-get install -y bzip2 wget && \
     rm -r /var/lib/apt/lists/* && \
     rm -r /var/cache/apt/* && \
     wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
     mkdir ${MAMBA_ROOT_PREFIX} && \
     micromamba install -y --prefix ${MAMBA_ROOT_PREFIX} -c bioconda -c conda-forge \
-    bazam biobambam samtools google-cloud-sdk \
-    && \
-    rm -r /root/micromamba/pkgs \
-
-RUN apt-get update && apt-get install -y build-essential curl libboost-all-dev && \
-    rm -r /var/lib/apt/lists/* && \
-    rm -r /var/cache/apt/* && \
-    git clone --depth 1 --branch ${VERSION} https://github.com/Illumina/DRAGMAP && \
-    cd DRAGMAP && \
-    HAS_GTEST=0 make -j 8 && \
-    mkdir ${MAMBA_ROOT_PREFIX}/bin && \
-    mv build/release/dragen-os ${MAMBA_ROOT_PREFIX}/bin/ && \
-    cd .. && \
-    rm -r /DRAGMAP
+        bazam biobambam dragmap=$VERSION google-cloud-sdk samtools && \
+    rm -r /root/micromamba/pkgs


### PR DESCRIPTION
This seems to work fine for 1.3.0 by now.