### PR TITLE
Container with BaseSpace CLI installed

### DIFF
--- a/images/basespace/Dockerfile
+++ b/images/basespace/Dockerfile
@@ -6,4 +6,3 @@ RUN apt-get update && \
     mkdir $HOME/bin && \
     wget "https://launch.basespace.illumina.com/CLI/latest/amd64-linux/bs" -O $HOME/bin/bs && \
     chmod u+x $HOME/bin/bs
-    

--- a/images/basespace/Dockerfile
+++ b/images/basespace/Dockerfile
@@ -1,0 +1,9 @@
+FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver-base:1.4
+
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+RUN apt-get update && \
+    mkdir $HOME/bin && \
+    wget "https://launch.basespace.illumina.com/CLI/latest/amd64-linux/bs" -O $HOME/bin/bs && \
+    chmod u+x $HOME/bin/bs
+    

--- a/images/basespace/Dockerfile
+++ b/images/basespace/Dockerfile
@@ -1,7 +1,5 @@
 FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver-base:1.4
 
-SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
-
 RUN apt-get update && \
     mkdir $HOME/bin && \
     wget "https://launch.basespace.illumina.com/CLI/latest/amd64-linux/bs" -O $HOME/bin/bs && \


### PR DESCRIPTION
A container image based on the AR driver base, which just installs BaseSpace CLI to the $HOME/bin/bs directory

See https://github.com/populationgenomics/transfer-private/pull/7 for intended use