### PR TITLE
Authenticate GitHub access in actions workflow

### DIFF
--- a/.github/workflows/deploy_config.yaml
+++ b/.github/workflows/deploy_config.yaml
@@ -19,10 +19,10 @@ jobs:
       matrix: ${{ steps.set_matrix.outputs.matrix }}
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Checkout ref before change"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.before }}
           path: 'before'
@@ -50,7 +50,7 @@ jobs:
       BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: google-github-actions/setup-gcloud@v0
         with:
@@ -81,7 +81,7 @@ jobs:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
       with:
         repository: "populationgenomics/production-pipelines"
         ref: "main"
@@ -138,7 +138,7 @@ jobs:
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     steps:
       - name: "checkout repo"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "gcloud setup"
         uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/deploy_config.yaml
+++ b/.github/workflows/deploy_config.yaml
@@ -87,6 +87,8 @@ jobs:
         ref: "main"
         path: "production-pipelines"
         submodules: recursive
+        # Comment this line out to revert to using the default $GITHUB_TOKEN.
+        token: ${{ secrets.PRODUCTION_PIPELINES_RAW_REPO_TOKEN }}
 
     - id: get_version
       run: |

--- a/.github/workflows/deploy_container.yaml
+++ b/.github/workflows/deploy_container.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: "checkout repo"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "gcloud setup"
         uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,9 +9,9 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
The default $GITHUB_TOKEN is useful only for this populationgenomics/images repository; it has no permissions for production-pipelines. Use a suitable PAT for when the latter repo is, for example, temporarily made private for operational reasons.

The secret name used here includes `_RAW_ `to indicate that its value must be just the text of the PAT, not the `url=` / `username=` / `password=` format used in other repositories' workflows.
    
Unfortunately this line must be removed or commented out to revert to using the default $GITHUB_TOKEN. With the technique used in other repositories, deleting the secret means `git credential approve` doesn't add anything and it reverts to unauthenticated access. However for this workflow the token is an argument to the `actions/checkout` action and [`token: /* empty */` leads to an error](https://github.com/jmarshall/test/actions/runs/5791310414/job/15695924514) so the line must be omitted.

While we're here, also update the versions of the various Actions used.