### PR TITLE
Add samtools to vep 110

### DIFF
--- a/images/vep_110/Dockerfile
+++ b/images/vep_110/Dockerfile
@@ -1,6 +1,7 @@
 ARG VERSION=${VERSION:-release_110.1}
 
 FROM ensemblorg/ensembl-vep:${VERSION}
+ARG HTS_VERSION=${HTS_VERSION:-1.18}
 
 USER root
 
@@ -48,8 +49,11 @@ ENV LOFTOOL_SCORES=/data/loftool_110_scores.txt
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
+        build-essential \
         ca-certificates \
         git \
+        libncurses5-dev \
+        wget \
     && curl https://raw.githubusercontent.com/Ensembl/UTRannotator/master/uORF_5UTR_GRCh38_PUBLIC.txt > ${UTR38} \
     && curl https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/110/pLI_values.txt > ${PLI_SCORES} \
     && curl https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/110/AlphaMissense.pm > ${VEP_DIR_PLUGINS}/AlphaMissense.pm \
@@ -68,3 +72,5 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         && cd .. \
         && rm -rf samtools-${HTS_VERSION}.tar.bz2 samtools-${HTS_VERSION} \
     && PERL_MM_USE_DEFAULT=1 cpan Ensembl::XS Bio::DB::HTS
+
+ENV PATH="/opt/vep/src/ensembl-vep/bin:$PATH"

--- a/images/vep_110/Dockerfile
+++ b/images/vep_110/Dockerfile
@@ -59,4 +59,12 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && rm -rf loftee \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* \
+    && wget -q https://github.com/samtools/samtools/releases/download/${HTS_VERSION}/samtools-${HTS_VERSION}.tar.bz2 \
+        && tar -xf samtools-${HTS_VERSION}.tar.bz2 \
+        && cd samtools-${HTS_VERSION} \
+        && bash configure --prefix=/opt/vep/src/ensembl-vep \
+        && make \
+        && make install \
+        && cd .. \
+        && rm -rf samtools-${HTS_VERSION}.tar.bz2 samtools-${HTS_VERSION} \
     && PERL_MM_USE_DEFAULT=1 cpan Ensembl::XS Bio::DB::HTS


### PR DESCRIPTION
I previously submitted this PR: https://github.com/populationgenomics/images/pull/104

Long story short - I was adding Samtools to the image, but in the PR I incorrectly stated I was installing Tabix. John correctly identified that the image would already had Tabix installed. I had a brain fart and closed the PR, opening a new one without Samtools... Sigh.

This error has surfaced now that the image has moved to a new name (`ensembl-vep` -> `vep_110`). I built `ensembl-vep` from the branch, and `vep_110` has been built from main (no Samtools).