### PR TITLE
Remove Prod-Pipes PAT

### DIFF
--- a/.github/workflows/deploy_config.yaml
+++ b/.github/workflows/deploy_config.yaml
@@ -87,8 +87,6 @@ jobs:
         ref: "main"
         path: "production-pipelines"
         submodules: recursive
-        # Comment this line out to revert to using the default $GITHUB_TOKEN.
-        token: ${{ secrets.PRODUCTION_PIPELINES_RAW_REPO_TOKEN }}
 
     - id: get_version
       run: |
@@ -141,7 +139,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "gcloud setup"
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id:  ${{ env.PROJECT }}
           service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}

--- a/.github/workflows/deploy_config.yaml
+++ b/.github/workflows/deploy_config.yaml
@@ -87,6 +87,8 @@ jobs:
         ref: "main"
         path: "production-pipelines"
         submodules: recursive
+        # Un-comment this line to use private access token if PP goes private
+        # token: ${{ secrets.PRODUCTION_PIPELINES_RAW_REPO_TOKEN }}
 
     - id: get_version
       run: |


### PR DESCRIPTION
Repo is no longer private, and this expired token is crashing the deploy workflow
Also bumps the gcloud setup workflow which is available at `V1`
https://github.com/marketplace/actions/set-up-gcloud-cloud-sdk-environment