### PR TITLE
Update actions to use google-github-actions/auth@v1 and fix input syntax

### DIFF
--- a/.github/workflows/deploy_config.yaml
+++ b/.github/workflows/deploy_config.yaml
@@ -52,10 +52,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: google-github-actions/setup-gcloud@v0
+      - id: "google-cloud-auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
         with:
-          project_id: cpg-common
-          service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}
+          workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "gh-images-deployer@cpg-common.iam.gserviceaccount.com"
+
+      - id: "google-cloud-sdk-setup"
+        name: "Set up Cloud SDK"
+        uses: google-github-actions/setup-gcloud@v1
 
       - run: |
           gcloud auth configure-docker ${{ env.DOCKER_PREFIX }}
@@ -100,10 +106,16 @@ jobs:
         echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
         cd -
 
-    - uses: google-github-actions/setup-gcloud@v0
+    - id: "google-cloud-auth"
+      name: "Authenticate to Google Cloud"
+      uses: "google-github-actions/auth@v1"
       with:
-        project_id: cpg-common
-        service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}
+        workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+        service_account: "gh-images-deployer@cpg-common.iam.gserviceaccount.com"
+
+    - id: "google-cloud-sdk-setup"
+      name: "Set up Cloud SDK"
+      uses: google-github-actions/setup-gcloud@v1
 
     - run: |
         gcloud auth configure-docker ${{ env.DOCKER_PREFIX }}
@@ -140,12 +152,15 @@ jobs:
       - name: "checkout repo"
         uses: actions/checkout@v3
 
-      - name: "auth service-account"
-        uses: google-github-actions/auth@v1
+      - id: "google-cloud-auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
         with:
-          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+          workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "gh-images-deployer@cpg-common.iam.gserviceaccount.com"
 
-      - name: "gcloud setup"
+      - id: "google-cloud-sdk-setup"
+        name: "Set up Cloud SDK"
         uses: google-github-actions/setup-gcloud@v1
         with:
           project_id:  ${{ env.PROJECT }}

--- a/.github/workflows/deploy_config.yaml
+++ b/.github/workflows/deploy_config.yaml
@@ -140,11 +140,15 @@ jobs:
       - name: "checkout repo"
         uses: actions/checkout@v3
 
+      - name: "auth service-account"
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
       - name: "gcloud setup"
         uses: google-github-actions/setup-gcloud@v1
         with:
           project_id:  ${{ env.PROJECT }}
-          service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/deploy_config.yaml
+++ b/.github/workflows/deploy_config.yaml
@@ -5,6 +5,10 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   PROJECT: 'cpg-common'
   CONFIG_DESTINATION: 'gs://cpg-config/templates/images/images.toml'

--- a/.github/workflows/deploy_container.yaml
+++ b/.github/workflows/deploy_container.yaml
@@ -12,6 +12,10 @@ on:
         description: "Extra docker CLI params"
         required: false
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deployImage:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_container.yaml
+++ b/.github/workflows/deploy_container.yaml
@@ -31,11 +31,15 @@ jobs:
       - name: "checkout repo"
         uses: actions/checkout@v3
 
+      - name: "auth service-account"
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
       - name: "gcloud setup"
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: analysis-runner
-          service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}
 
       - name: "gcloud docker auth"
         run: |

--- a/.github/workflows/deploy_container.yaml
+++ b/.github/workflows/deploy_container.yaml
@@ -31,15 +31,16 @@ jobs:
       - name: "checkout repo"
         uses: actions/checkout@v3
 
-      - name: "auth service-account"
-        uses: google-github-actions/auth@v1
+      - id: "google-cloud-auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
         with:
-          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+          workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "gh-images-deployer@cpg-common.iam.gserviceaccount.com"
 
-      - name: "gcloud setup"
+      - id: "google-cloud-sdk-setup"
+        name: "Set up Cloud SDK"
         uses: google-github-actions/setup-gcloud@v1
-        with:
-          project_id: analysis-runner
 
       - name: "gcloud docker auth"
         run: |


### PR DESCRIPTION
So it looks like the new version of `google-github-actions/setup-gcloud@v1` action no longer uses `service_account_key` as input. See [this failed deploy](https://github.com/populationgenomics/images/actions/runs/6886508598/job/18732356675), under the gcloud setup header. 
```
Warning: Unexpected input(s) 'service_account_key', valid inputs are ['skip_install', 'version', 'project_id', 'install_components']
...
Warning: No authentication found for gcloud, authenticate with `google-github-actions/auth`.
```
Which is leading to a fail in the `deploy config toml` step.
```
ERROR: (gcloud.storage.cp) You do not currently have an active account selected.
Please run:

  $ gcloud auth login

to obtain new credentials.
```

From the actions repo, it looks like they now require use of the `google-github-actions/auth` action to first auth with the `service_account_key` (now called `credentials_json`) before running the gcloud setup.


Also updates the `.github/workflows/deploy_container.yaml` to use the `@v1` version of the gcloud setup as well.