### PR TITLE
Use a similar download URL to those micromamba itself uses

### DIFF
--- a/images/samtools/Dockerfile
+++ b/images/samtools/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION=${VERSION:-1.18}
 RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
     rm -r /var/lib/apt/lists/* && \
     rm -r /var/cache/apt/* && \
-    wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
+    wget -qO- https://conda.anaconda.org/conda-forge/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
     mkdir ${MAMBA_ROOT_PREFIX} && \
     micromamba install -y --prefix ${MAMBA_ROOT_PREFIX} -c bioconda -c conda-forge \
     samtools=${VERSION} google-cloud-sdk dill && \


### PR DESCRIPTION
The initial download of micromamba*.tar.bz2 from api.anaconda.org has recently begun failing when run under docker, presumably due to network setup changes elsewhere.

See https://centrepopgen.slack.com/archives/C03FZL2EF24/p1699837108996249 for context.

Fortunately `micromamba install …` itself still works from docker, so we can use `micromamba install -v` to observe the URL style it uses when downloading and installing other packages, and use the same hostname and URL style to do our initial manual download of the micromamba package.