### PR TITLE
Ensure dill etc are installed for Python 3.10

### DIFF
--- a/images/samtools/Dockerfile
+++ b/images/samtools/Dockerfile
@@ -10,5 +10,5 @@ RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
     wget -qO- https://conda.anaconda.org/conda-forge/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
     mkdir ${MAMBA_ROOT_PREFIX} && \
     micromamba install -y --prefix ${MAMBA_ROOT_PREFIX} -c bioconda -c conda-forge \
-    samtools=${VERSION} google-cloud-sdk dill && \
+    samtools=${VERSION} python=3.10 google-cloud-sdk dill && \
     rm -r /root/micromamba/pkgs


### PR DESCRIPTION
Final fix to make a samtools image that Hail can use for its Python jobs: hail needs to run dill using the same Python version as the driver image.

This image has been built into …/images-dev and successfully used for a test run of CRAM reheadering: see <https://batch.hail.populationgenomics.org.au/batches/430054>.