### PR TITLE
Minimal gcsfuse image

### DIFF
--- a/images/gcsfuse/Dockerfile
+++ b/images/gcsfuse/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:22.04
+
+ARG VERSION=${VERSION:-1.0}
+
+RUN GCSFUSE_REPO=gcsfuse-$(lsb_release -c -s) && \
+    echo "deb http://packages.cloud.google.com/apt $GCSFUSE_REPO main" | tee /etc/apt/sources.list.d/gcsfuse.list && \
+    wget -qO - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    apt-get update && apt-get install -y gcsfuse


### PR DESCRIPTION
Installs only gcsfuse, for mounting buckets in Hail jobs with write privileges.