### PR TITLE
Environment Lock

### DIFF
--- a/.github/workflows/deploy_config.yaml
+++ b/.github/workflows/deploy_config.yaml
@@ -19,14 +19,15 @@ jobs:
   # Make a matrix of all the images that have changed in images.toml
   make_matrix:
     runs-on: ubuntu-latest
+    environment: production
     outputs:
       matrix: ${{ steps.set_matrix.outputs.matrix }}
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Checkout ref before change"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.before }}
           path: 'before'
@@ -44,6 +45,7 @@ jobs:
   # Deploy the images that have changed to the registry
   deploy_images:
     runs-on: ubuntu-latest
+    environment: production
     needs:
       - make_matrix
     if: ${{ needs.make_matrix.outputs.matrix != '{}' && needs.make_matrix.outputs.matrix != '' }}
@@ -54,11 +56,11 @@ jobs:
       BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: "google-cloud-auth"
         name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v1"
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           service_account: "gh-images-deployer@cpg-common.iam.gserviceaccount.com"
@@ -86,12 +88,13 @@ jobs:
   # here and build it from the repository source, using the package version as the tag.
   deploy_cpg_workflows:
     runs-on: ubuntu-latest
+    environment: production
     env:
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: "populationgenomics/production-pipelines"
         ref: "main"
@@ -112,7 +115,7 @@ jobs:
 
     - id: "google-cloud-auth"
       name: "Authenticate to Google Cloud"
-      uses: "google-github-actions/auth@v1"
+      uses: "google-github-actions/auth@v2"
       with:
         workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
         service_account: "gh-images-deployer@cpg-common.iam.gserviceaccount.com"
@@ -146,6 +149,7 @@ jobs:
   # special-case cpg_workflows.
   deploy_config:
     runs-on: ubuntu-latest
+    environment: production
     needs:
       - deploy_images
       - deploy_cpg_workflows
@@ -154,11 +158,11 @@ jobs:
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     steps:
       - name: "checkout repo"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: "google-cloud-auth"
         name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v1"
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           service_account: "gh-images-deployer@cpg-common.iam.gserviceaccount.com"

--- a/.github/workflows/deploy_container.yaml
+++ b/.github/workflows/deploy_container.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           docker tag $DOCKER_IMAGE $DOCKER_MAIN$DOCKER_IMAGE
           docker push $DOCKER_MAIN$DOCKER_IMAGE
-  
+
   deploy_image_dev:
     runs-on: ubuntu-latest
     environment: dev

--- a/.github/workflows/deploy_container.yaml
+++ b/.github/workflows/deploy_container.yaml
@@ -17,14 +17,13 @@ permissions:
   contents: read
 
 jobs:
-  deployImage:
+  deploy_image_prod:
     runs-on: ubuntu-latest
-
+    environment: production
     env:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-      DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev/
       DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images/
       DOCKER_IMAGE: ${{ github.event.inputs.image_name }}:${{ github.event.inputs.image_tag }}
       IMAGE_NAME: ${{ github.event.inputs.image_name }}
@@ -33,14 +32,60 @@ jobs:
     steps:
 
       - name: "checkout repo"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: "google-cloud-auth"
         name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v1"
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           service_account: "gh-images-deployer@cpg-common.iam.gserviceaccount.com"
+
+      - id: "google-cloud-sdk-setup"
+        name: "Set up Cloud SDK"
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: "gcloud docker auth"
+        run: |
+          gcloud auth configure-docker australia-southeast1-docker.pkg.dev
+
+      - name: "build image"
+        run: |
+          docker build \
+            ${{ inputs.docker_cli_args }} \
+            --build-arg VERSION=$IMAGE_TAG \
+            --tag $DOCKER_IMAGE \
+            images/$IMAGE_NAME
+
+      - name: "Push main branch to core artifactory"
+        if: ${{ github.ref_name == 'main' }}
+        run: |
+          docker tag $DOCKER_IMAGE $DOCKER_MAIN$DOCKER_IMAGE
+          docker push $DOCKER_MAIN$DOCKER_IMAGE
+  
+  deploy_image_dev:
+    runs-on: ubuntu-latest
+    environment: dev
+    env:
+      DOCKER_BUILDKIT: 1
+      BUILDKIT_PROGRESS: plain
+      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+      DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev/
+      DOCKER_IMAGE: ${{ github.event.inputs.image_name }}:${{ github.event.inputs.image_tag }}
+      IMAGE_NAME: ${{ github.event.inputs.image_name }}
+      IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+
+    steps:
+
+      - name: "checkout repo"
+        uses: actions/checkout@v4
+
+      - id: "google-cloud-auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v2"
+        with:
+          workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "gh-images-dev-deployer@cpg-common.iam.gserviceaccount.com"
 
       - id: "google-cloud-sdk-setup"
         name: "Set up Cloud SDK"
@@ -63,9 +108,3 @@ jobs:
         run: |
           docker tag $DOCKER_IMAGE $DOCKER_DEV$DOCKER_IMAGE
           docker push $DOCKER_DEV$DOCKER_IMAGE
-
-      - name: "Push main branch to core artifactory"
-        if: ${{ github.ref_name == 'main' }}
-        run: |
-          docker tag $DOCKER_IMAGE $DOCKER_MAIN$DOCKER_IMAGE
-          docker push $DOCKER_MAIN$DOCKER_IMAGE


### PR DESCRIPTION
## Description
In a bid to introduce better security permissions, we have replaced the use of SA keys to workload identity providers where possible. We will also ensure the workload federated identities are attached to an environment in the repo. 

## Changes
- [x]  Updated the workflow to use WIP and separated it into two jobs, one for prod and one for dev
- [x]  Added `environment` attribute to the `deploy_*` workflows