### PR TITLE
Add susieR to the dockerfile

### DIFF
--- a/images/r-meta/Dockerfile
+++ b/images/r-meta/Dockerfile
@@ -24,7 +24,7 @@ RUN apt update && \
         r-devtools \
         r-essentials \
         r-meta \
-        # r-susieR \
+        r-susieR \
         r-tidyverse \
         r-viridis && \
     rm -r /root/micromamba/pkgs && \

--- a/images/r-meta/Dockerfile
+++ b/images/r-meta/Dockerfile
@@ -12,7 +12,7 @@ RUN apt update && \
     apt install -y build-essential && \
     rm -r /var/lib/apt/lists/* && \
     rm -r /var/cache/apt/* && \
-    wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C /usr/local bin/micromamba && \
+    curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba && \
     mkdir $MAMBA_ROOT_PREFIX && \
     micromamba install -y --prefix $MAMBA_ROOT_PREFIX \
         -c cpg -c bioconda -c conda-forge \

--- a/images/r-meta/Dockerfile
+++ b/images/r-meta/Dockerfile
@@ -12,7 +12,7 @@ RUN apt update && \
     apt install -y build-essential && \
     rm -r /var/lib/apt/lists/* && \
     rm -r /var/cache/apt/* && \
-    wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
+    wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C /usr/local bin/micromamba && \
     mkdir $MAMBA_ROOT_PREFIX && \
     micromamba install -y --prefix $MAMBA_ROOT_PREFIX \
         -c cpg -c bioconda -c conda-forge \

--- a/images/r-meta/Dockerfile
+++ b/images/r-meta/Dockerfile
@@ -24,6 +24,7 @@ RUN apt update && \
         r-devtools \
         r-essentials \
         r-meta \
+        r-susieR \
         r-tidyverse \
         r-viridis && \
     rm -r /root/micromamba/pkgs && \

--- a/images/r-meta/Dockerfile
+++ b/images/r-meta/Dockerfile
@@ -33,6 +33,5 @@ RUN apt update && \
         anndata2ri \
         cloudpathlib[all] \
         cpg-utils \
-        cpg-workflows \
         gcsfs \
         pandas

--- a/images/r-meta/Dockerfile
+++ b/images/r-meta/Dockerfile
@@ -24,7 +24,7 @@ RUN apt update && \
         r-devtools \
         r-essentials \
         r-meta \
-        r-susieR \
+        # r-susieR \
         r-tidyverse \
         r-viridis && \
     rm -r /root/micromamba/pkgs && \

--- a/images/r-meta/Dockerfile
+++ b/images/r-meta/Dockerfile
@@ -12,7 +12,7 @@ RUN apt update && \
     apt install -y build-essential && \
     rm -r /var/lib/apt/lists/* && \
     rm -r /var/cache/apt/* && \
-    curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba && \
+    wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
     mkdir $MAMBA_ROOT_PREFIX && \
     micromamba install -y --prefix $MAMBA_ROOT_PREFIX \
         -c cpg -c bioconda -c conda-forge \


### PR DESCRIPTION
I am making `r-meta` as an image for meta-analysis and downstream analysis after eQTL discovery - it will have `coloc` and `susieR` packages for colocalisation and finemapping analysis respectively. 

Confirming the image works in my test scripts. 