### PR TITLE
Refactor deploy_image job and update actions versions used

### DIFF
--- a/.github/workflows/deploy_config.yaml
+++ b/.github/workflows/deploy_config.yaml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.event.before }}
           path: 'before'
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -67,7 +67,7 @@ jobs:
 
       - id: "google-cloud-sdk-setup"
         name: "Set up Cloud SDK"
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
 
       - run: |
           gcloud auth configure-docker ${{ env.DOCKER_PREFIX }}
@@ -122,7 +122,7 @@ jobs:
 
     - id: "google-cloud-sdk-setup"
       name: "Set up Cloud SDK"
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
 
     - run: |
         gcloud auth configure-docker ${{ env.DOCKER_PREFIX }}
@@ -169,11 +169,11 @@ jobs:
 
       - id: "google-cloud-sdk-setup"
         name: "Set up Cloud SDK"
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id:  ${{ env.PROJECT }}
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/deploy_container.yaml
+++ b/.github/workflows/deploy_container.yaml
@@ -17,20 +17,20 @@ permissions:
   contents: read
 
 jobs:
-  deploy_image_prod:
+  deploy_image:
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{ github.ref_name == 'main' && 'production' || 'dev' }}
     env:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+      DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev/
       DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images/
       DOCKER_IMAGE: ${{ github.event.inputs.image_name }}:${{ github.event.inputs.image_tag }}
       IMAGE_NAME: ${{ github.event.inputs.image_name }}
       IMAGE_TAG: ${{ github.event.inputs.image_tag }}
 
     steps:
-
       - name: "checkout repo"
         uses: actions/checkout@v4
 
@@ -39,7 +39,7 @@ jobs:
         uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
-          service_account: "gh-images-deployer@cpg-common.iam.gserviceaccount.com"
+          service_account: "gh-images-${{ github.ref_name == 'main' && 'deployer' || 'dev-deployer' }}@cpg-common.iam.gserviceaccount.com"
 
       - id: "google-cloud-sdk-setup"
         name: "Set up Cloud SDK"
@@ -62,46 +62,6 @@ jobs:
         run: |
           docker tag $DOCKER_IMAGE $DOCKER_MAIN$DOCKER_IMAGE
           docker push $DOCKER_MAIN$DOCKER_IMAGE
-
-  deploy_image_dev:
-    runs-on: ubuntu-latest
-    environment: dev
-    env:
-      DOCKER_BUILDKIT: 1
-      BUILDKIT_PROGRESS: plain
-      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-      DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev/
-      DOCKER_IMAGE: ${{ github.event.inputs.image_name }}:${{ github.event.inputs.image_tag }}
-      IMAGE_NAME: ${{ github.event.inputs.image_name }}
-      IMAGE_TAG: ${{ github.event.inputs.image_tag }}
-
-    steps:
-
-      - name: "checkout repo"
-        uses: actions/checkout@v4
-
-      - id: "google-cloud-auth"
-        name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v2"
-        with:
-          workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
-          service_account: "gh-images-dev-deployer@cpg-common.iam.gserviceaccount.com"
-
-      - id: "google-cloud-sdk-setup"
-        name: "Set up Cloud SDK"
-        uses: google-github-actions/setup-gcloud@v1
-
-      - name: "gcloud docker auth"
-        run: |
-          gcloud auth configure-docker australia-southeast1-docker.pkg.dev
-
-      - name: "build image"
-        run: |
-          docker build \
-            ${{ inputs.docker_cli_args }} \
-            --build-arg VERSION=$IMAGE_TAG \
-            --tag $DOCKER_IMAGE \
-            images/$IMAGE_NAME
 
       - name: "Push non-main branch to dev artifactory"
         if: ${{ github.ref_name != 'main' }}

--- a/.github/workflows/deploy_container.yaml
+++ b/.github/workflows/deploy_container.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - id: "google-cloud-sdk-setup"
         name: "Set up Cloud SDK"
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: "gcloud docker auth"
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,9 +9,9 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
Recombine `deploy_image_prod`/`deploy_image_dev` into a single workflow by using [`${{ … }}`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example) to vary `environment` and `service_account` as appropriate. In particular, this avoids building the Docker image twice because both jobs are running in parallel.

Update the versions of the various actions used to [node20-based ones](https://github.blog/changelog/2024-09-25-end-of-life-for-actions-node16/).