### PR TITLE
Fresh implementation of #154

### DIFF
--- a/images.toml
+++ b/images.toml
@@ -1,5 +1,6 @@
 # Map of tags for cpg-common images
 bcftools = '1.16'
+bcftools_120 = '1.20'
 bedtools = '2.30.0'
 bwa = '0.7.17'
 cellregmap = '0.0.3'

--- a/images/bcftools_120/Dockerfile
+++ b/images/bcftools_120/Dockerfile
@@ -1,0 +1,41 @@
+FROM debian:bookworm-slim as base
+
+ARG VERSION=${VERSION:-1.20}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+        libbz2-1.0 \
+        libcurl4 \
+        liblzma5 \
+        libssl3 \
+        zlib1g && \
+    rm -r /var/lib/apt/lists/* && \
+    rm -r /var/cache/apt/*
+
+# second stage - add compile-relevant tools, obtain release, install from release
+FROM base as compiler
+
+RUN apt-get update && apt-get install -y \
+        bzip2 \
+        gcc \
+        libbz2-dev \
+        libcurl4-openssl-dev \
+        liblzma-dev \
+        libssl-dev \
+        make \
+        wget \
+        zlib1g-dev && \
+    wget https://github.com/samtools/bcftools/releases/download/${VERSION}/bcftools-${VERSION}.tar.bz2 && \
+    tar -xf bcftools-${VERSION}.tar.bz2 && \
+    cd bcftools-${VERSION} && \
+    ./configure --enable-libcurl --enable-s3 --enable-gcs && \
+    make && \
+    strip bcftools plugins/*.so && \
+    make DESTDIR=/bcftools_install install
+
+# the actual build - on minimal install, copy content from bcftools install directory
+from base
+
+COPY --from=compiler /bcftools_install/usr/local/bin/* /usr/local/bin/
+COPY --from=compiler /bcftools_install/usr/local/libexec/bcftools/* /usr/local/libexec/bcftools/

--- a/images/bcftools_120/Dockerfile
+++ b/images/bcftools_120/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as base
+FROM debian:bookworm-slim AS base
 
 ARG VERSION=${VERSION:-1.20}
 
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     rm -r /var/cache/apt/*
 
 # second stage - add compile-relevant tools, obtain release, install from release
-FROM base as compiler
+FROM base AS compiler
 
 RUN apt-get update && apt-get install -y \
         bzip2 \
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y \
     make DESTDIR=/bcftools_install install
 
 # the actual build - on minimal install, copy content from bcftools install directory
-from base
+FROM base
 
 COPY --from=compiler /bcftools_install/usr/local/bin/* /usr/local/bin/
 COPY --from=compiler /bcftools_install/usr/local/libexec/bcftools/* /usr/local/libexec/bcftools/


### PR DESCRIPTION
#154 was effectively abandoned because nobody (justifiably) wanted to just replace the current bcftools image which is used all over the cpg_workflows codebase

This re-opens #154 but instead of upgrading the bcftools image in place, it adds a parallel version `bcftools_120`.

@jmarshall has already polished this build down to a cool 35MB, and I've already been using the image built from #154 in production workflows... Albeit from the dev-image store, naughty.

https://github.com/populationgenomics/production-pipelines/blob/main/configs/defaults/clinvarbitration.toml#L6

Code/image duplication aside, this is a super lean build and would be a good template for lean single-tool images