### PR TITLE
 Install pip inside ICA image

### DIFF
--- a/images/ica/Dockerfile
+++ b/images/ica/Dockerfile
@@ -17,6 +17,7 @@ RUN apt update && apt install -y \
     rm -rf /tmp/ica-linux-amd64.sha256 /tmp/ica-linux-amd64.zip /tmp/linux-amd64
 
 RUN pip install git+https://github.com/Illumina/ica-sdk-python.git \
-    && pip install typing-extensions --upgrade
+    && pip install typing-extensions --upgrade \
+    && pip install dill
 
 ENV PATH=$PATH:/opt/google-cloud-sdk/bin


### PR DESCRIPTION
Hitting issues with running ICA pipeline using standalone ICA image [here](https://batch.hail.populationgenomics.org.au/batches/589302/jobs/1)
Adding Dill package to ICA image so that PythonJob arguments can get de/serialised.

