### PR TITLE
Show link to built image as last step of the CI.

### DIFF
--- a/.github/workflows/deploy_container.yaml
+++ b/.github/workflows/deploy_container.yaml
@@ -62,9 +62,11 @@ jobs:
         run: |
           docker tag $DOCKER_IMAGE $DOCKER_MAIN$DOCKER_IMAGE
           docker push $DOCKER_MAIN$DOCKER_IMAGE
+          echo "Link to image: https://console.cloud.google.com/artifacts/docker/cpg-common/australia-southeast1/images/$IMAGE_NAME?project=cpg-common"
 
       - name: "Push non-main branch to dev artifactory"
         if: ${{ github.ref_name != 'main' }}
         run: |
           docker tag $DOCKER_IMAGE $DOCKER_DEV$DOCKER_IMAGE
           docker push $DOCKER_DEV$DOCKER_IMAGE
+          echo "Link to image: https://console.cloud.google.com/artifacts/docker/cpg-common/australia-southeast1/images-dev/$IMAGE_NAME?project=cpg-common"

--- a/.github/workflows/deploy_container.yaml
+++ b/.github/workflows/deploy_container.yaml
@@ -62,11 +62,13 @@ jobs:
         run: |
           docker tag $DOCKER_IMAGE $DOCKER_MAIN$DOCKER_IMAGE
           digest=$(docker push $DOCKER_MAIN$DOCKER_IMAGE | tee /dev/tty | grep "digest:" | awk '{print $2}')
-          echo "Link to image: https://console.cloud.google.com/artifacts/docker/cpg-common/australia-southeast1/images/$IMAGE_NAME/$digest?project=cpg-common"
+          echo ":package: Link to image:" >> $GITHUB_STEP_SUMMARY
+          echo "https://console.cloud.google.com/artifacts/docker/cpg-common/australia-southeast1/images/$IMAGE_NAME/$digest?project=cpg-common" >> $GITHUB_STEP_SUMMARY
 
       - name: "Push non-main branch to dev artifactory"
         if: ${{ github.ref_name != 'main' }}
         run: |
           docker tag $DOCKER_IMAGE $DOCKER_DEV$DOCKER_IMAGE
           digest=$(docker push $DOCKER_DEV$DOCKER_IMAGE | tee /dev/tty | grep "digest:" | awk '{print $2}')
-          echo "Link to image: https://console.cloud.google.com/artifacts/docker/cpg-common/australia-southeast1/images-dev/$IMAGE_NAME/$digest?project=cpg-common"
+          echo ":package: Link to image:" >> $GITHUB_STEP_SUMMARY
+          echo "https://console.cloud.google.com/artifacts/docker/cpg-common/australia-southeast1/images-dev/$IMAGE_NAME/$digest?project=cpg-common" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy_container.yaml
+++ b/.github/workflows/deploy_container.yaml
@@ -61,12 +61,12 @@ jobs:
         if: ${{ github.ref_name == 'main' }}
         run: |
           docker tag $DOCKER_IMAGE $DOCKER_MAIN$DOCKER_IMAGE
-          docker push $DOCKER_MAIN$DOCKER_IMAGE
-          echo "Link to image: https://console.cloud.google.com/artifacts/docker/cpg-common/australia-southeast1/images/$IMAGE_NAME?project=cpg-common"
+          digest=$(docker push $DOCKER_MAIN$DOCKER_IMAGE | tee /dev/tty | grep "digest:" | awk '{print $2}')
+          echo "Link to image: https://console.cloud.google.com/artifacts/docker/cpg-common/australia-southeast1/images/$IMAGE_NAME/$digest?project=cpg-common"
 
       - name: "Push non-main branch to dev artifactory"
         if: ${{ github.ref_name != 'main' }}
         run: |
           docker tag $DOCKER_IMAGE $DOCKER_DEV$DOCKER_IMAGE
-          docker push $DOCKER_DEV$DOCKER_IMAGE
-          echo "Link to image: https://console.cloud.google.com/artifacts/docker/cpg-common/australia-southeast1/images-dev/$IMAGE_NAME?project=cpg-common"
+          digest=$(docker push $DOCKER_DEV$DOCKER_IMAGE | tee /dev/tty | grep "digest:" | awk '{print $2}')
+          echo "Link to image: https://console.cloud.google.com/artifacts/docker/cpg-common/australia-southeast1/images-dev/$IMAGE_NAME/$digest?project=cpg-common"


### PR DESCRIPTION
This is implementation for task: 
https://cpg-populationanalysis.atlassian.net/browse/SET-414?atlOrigin=eyJpIjoiODViMGFlNWExNjY5NDIzYWJkOGZhMDEzYTgwYWU1MDkiLCJwIjoiaiJ9

After images gets pushed to registry it shows the link in the log output. 