### PR TITLE
Update SET-409 PR to use GitHub CLI to add/update PR comments 

### DIFF
--- a/.github/workflows/get_expected_tags.yaml
+++ b/.github/workflows/get_expected_tags.yaml
@@ -14,7 +14,6 @@ env:
 jobs:
   get_next_version:
     runs-on: ubuntu-latest
-    environment: production
     outputs:
       matrix: ${{ steps.get_next_version.outputs.next_version }}
     steps:
@@ -27,19 +26,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-
-      - id: 'google-cloud-auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          workload_identity_provider: 'projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
-          service_account: 'gh-images-deployer@cpg-common.iam.gserviceaccount.com'
-
-      - id: 'google-cloud-sdk-setup'
-        name: 'Set up Cloud SDK'
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: ${{ env.PROJECT }}
 
       - name: 'Get current version'
         id: get_next_version

--- a/.github/workflows/get_expected_tags.yaml
+++ b/.github/workflows/get_expected_tags.yaml
@@ -54,6 +54,8 @@ jobs:
     permissions:
       pull-requests: write
     if: ${{ needs.get_next_version.outputs.matrix != '{}' && needs.get_next_version.outputs.matrix != '' }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Read matrix JSON
         id: read-matrix
@@ -74,18 +76,6 @@ jobs:
             echo "| $NAME | $TAG |" >> table.md
           done
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: 🐳 Expected Tags
-
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body-path: table.md # ⬅️ Use file instead of an environment variable!
-          edit-mode: replace
+        run: |
+          gh pr comment --edit-last --create-if-none --body-file table.md ${{ github.event.pull_request.number }}

--- a/.github/workflows/get_expected_tags.yaml
+++ b/.github/workflows/get_expected_tags.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: 'Get current version'
         id: get_next_version
         run: |
+          gcloud config list account --format "value(core.account)"
           next_version=$(python .github/workflows/get_version.py)
           echo "next_version=$next_version" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/get_expected_tags.yaml
+++ b/.github/workflows/get_expected_tags.yaml
@@ -43,6 +43,9 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: 'Checkout repo'
+        uses: actions/checkout@v4
+
       - name: Read matrix JSON
         id: read-matrix
         env:

--- a/.github/workflows/get_version.py
+++ b/.github/workflows/get_version.py
@@ -3,6 +3,7 @@ import json
 import subprocess
 import re
 import os
+import sys
 
 
 def extract_version_from_file(file_path):
@@ -55,6 +56,7 @@ def get_next_version_tag(folder, version):
             pass
 
     max_suffix = 0
+    print(f'{tags_list=}', file=sys.stderr)
     pattern = re.compile(rf'^{re.escape(version)}-(\d+)$')
     for entry in tags_list:
         tags = entry.get('tags', [])
@@ -129,6 +131,7 @@ def main():
     # Build the final matrix structure.
     matrix = {'include': include_entries}
     print(json.dumps(matrix, separators=(',', ':')), end='')
+    print(f'{matrix=}', file=sys.stderr)
 
 
 main()

--- a/.github/workflows/get_version.py
+++ b/.github/workflows/get_version.py
@@ -47,12 +47,15 @@ def get_next_version_tag(folder, version):
             full_image_name,
             '--format=json',
         ]
+        print(f'Running {" ".join(cmd)}', file=sys.stderr)
         result = subprocess.run(cmd, capture_output=True, text=True)
+        print(f'{result.returncode=!r} {result.stdout=!r} {result.stderr=!r}', file=sys.stderr)
         if result.returncode != 0:
             return f'{version}-1'
         try:
             tags_list += json.loads(result.stdout)
-        except Exception:
+        except Exception as e:
+            print(f'Bork {e=}', file=sys.stderr)
             pass
 
     max_suffix = 0
@@ -78,6 +81,7 @@ def get_before_commit():
     - If on `main` with a merge: Finds the last two merge
     commits and compares them.
     """
+    print('Running git rev-parse --abbrev-ref HEAD', file=sys.stderr)
     current_branch = subprocess.run(
         ['git', 'rev-parse', '--abbrev-ref', 'HEAD'], capture_output=True, text=True
     ).stdout.strip()
@@ -116,6 +120,7 @@ def main():
 
     for file in dockerfiles:
         current_version = extract_version_from_file(file)
+        print(f'FOR {file=!r} {current_version=!r}', file=sys.stderr)
         if current_version is None:
             continue
 

--- a/images/dummy/Dockerfile
+++ b/images/dummy/Dockerfile
@@ -2,4 +2,4 @@ FROM docker.io/python:3.10-slim-bookworm
 
 # Hello this is a comment
 
-ENV VERSION=1.1
+ENV VERSION=1.2

--- a/images/dummy/Dockerfile
+++ b/images/dummy/Dockerfile
@@ -1,3 +1,5 @@
 FROM docker.io/python:3.10-slim-bookworm
 
+# Hello this is a comment
+
 ENV VERSION=1.1

--- a/images/dummy/Dockerfile
+++ b/images/dummy/Dockerfile
@@ -1,3 +1,3 @@
 FROM docker.io/python:3.10-slim-bookworm
 
-ENV VERSION=1.0
+ENV VERSION=1.1


### PR DESCRIPTION
This is a GitHub product that is already installed on the runner image, and should be more immune to supply chain attacks than these (already fairly safe) GH actions.