### PR TITLE
Remove unnecessary CI step in revamped workflow

### DIFF
--- a/.github/workflows/revamp.yaml
+++ b/.github/workflows/revamp.yaml
@@ -1,4 +1,4 @@
-name: Deploy with Versioning
+name: Revamped Deploy with Versioning
 on:
   push:
     branches:

--- a/.github/workflows/revamp.yaml
+++ b/.github/workflows/revamp.yaml
@@ -96,7 +96,7 @@ jobs:
   # Special-case for cpg_workflows: the image is not maintained via images.toml here
   # as we have a repository production-pipelines for it, so we check out that repo
   # here and build it from the repository source, using the package version as the tag.
-  deploy_cpg_workflows:
+  get_cpg_workflows_version:
     runs-on: ubuntu-latest
     environment: production
     env:
@@ -116,44 +116,6 @@ jobs:
         run: |
           echo "version=$(cat production-pipelines/.bumpversion.cfg | grep 'current_version = ' | sed 's/current_version = //')" >> $GITHUB_OUTPUT
 
-      - id: get_sha
-        run: |
-          cd production-pipelines
-          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-          cd -
-
-      - id: 'google-cloud-auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          workload_identity_provider: 'projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
-          service_account: 'gh-images-deployer@cpg-common.iam.gserviceaccount.com'
-
-      - id: 'google-cloud-sdk-setup'
-        name: 'Set up Cloud SDK'
-        uses: google-github-actions/setup-gcloud@v2
-
-      - run: |
-          gcloud auth configure-docker ${{ env.DOCKER_PREFIX }}
-
-      - name: build
-        run: |
-          IMAGE_NAME=${{ env.IMAGES_PREFIX }}/cpg_workflows
-          docker build production-pipelines --tag $IMAGE_NAME:${{ steps.get_sha.outputs.sha }}
-
-      - name: push
-        run: |
-          IMAGE_NAME=${{ env.IMAGES_PREFIX }}/cpg_workflows
-          docker push $IMAGE_NAME:${{ steps.get_sha.outputs.sha }}
-
-      - name: push latest
-        run: |
-          IMAGE_NAME=${{ env.IMAGES_PREFIX }}/cpg_workflows
-          docker tag $IMAGE_NAME:${{ steps.get_sha.outputs.sha }} $IMAGE_NAME:${{ steps.get_version.outputs.version }}
-          docker tag $IMAGE_NAME:${{ steps.get_sha.outputs.sha }} $IMAGE_NAME:latest
-          docker push $IMAGE_NAME:${{ steps.get_version.outputs.version }}
-          docker push $IMAGE_NAME:latest
-
   # Finally, prepare the finalised TOML config from all maintained images plus the
   # special-case cpg_workflows.
   deploy_config:
@@ -161,7 +123,7 @@ jobs:
     environment: production
     needs:
       - deploy_images
-      - deploy_cpg_workflows
+      - get_cpg_workflows_version
     if: ${{ ! failure() }}
     env:
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
@@ -190,7 +152,7 @@ jobs:
         run: |
           pip install toml
           python .github/workflows/prep_config.py \
-          ${{ needs.deploy_cpg_workflows.outputs.version }} > config.toml
+          ${{ needs.get_cpg_workflows_version.outputs.version }} > config.toml
 
       - name: 'deploy config toml'
         run: |

--- a/.github/workflows/revamp_dev.yaml
+++ b/.github/workflows/revamp_dev.yaml
@@ -1,4 +1,4 @@
-name: Deploy Dev Image
+name: Revamped Deploy Dev Image
 on:
   pull_request:
     types: [opened, synchronize]


### PR DESCRIPTION
This basically copies in the changes from PR #184 to remove the step that builds images for cpg_workflows as we no longer need it. Additional details can be found on the PR above.

We also want to rename the new workflows to make them distinct.