### PR TITLE
Add bcftools v1.21 dockerfile

### DIFF
--- a/images/bcftools_121/Dockerfile
+++ b/images/bcftools_121/Dockerfile
@@ -1,7 +1,8 @@
 FROM debian:bookworm-slim AS base
 
-ARG VERSION=${VERSION:-1.20}
+ARG VERSION=${VERSION:-1.21}
 
+ENV VERSION=1.21
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \

--- a/images/bcftools_121/Dockerfile
+++ b/images/bcftools_121/Dockerfile
@@ -1,0 +1,41 @@
+FROM debian:bookworm-slim AS base
+
+ARG VERSION=${VERSION:-1.20}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+        libbz2-1.0 \
+        libcurl4 \
+        liblzma5 \
+        libssl3 \
+        zlib1g && \
+    rm -r /var/lib/apt/lists/* && \
+    rm -r /var/cache/apt/*
+
+# second stage - add compile-relevant tools, obtain release, install from release
+FROM base AS compiler
+
+RUN apt-get update && apt-get install -y \
+        bzip2 \
+        gcc \
+        libbz2-dev \
+        libcurl4-openssl-dev \
+        liblzma-dev \
+        libssl-dev \
+        make \
+        wget \
+        zlib1g-dev && \
+    wget https://github.com/samtools/bcftools/releases/download/${VERSION}/bcftools-${VERSION}.tar.bz2 && \
+    tar -xf bcftools-${VERSION}.tar.bz2 && \
+    cd bcftools-${VERSION} && \
+    ./configure --enable-libcurl --enable-s3 --enable-gcs && \
+    make && \
+    strip bcftools plugins/*.so && \
+    make DESTDIR=/bcftools_install install
+
+# the actual build - on minimal install, copy content from bcftools install directory
+FROM base
+
+COPY --from=compiler /bcftools_install/usr/local/bin/* /usr/local/bin/
+COPY --from=compiler /bcftools_install/usr/local/libexec/bcftools/* /usr/local/libexec/bcftools/


### PR DESCRIPTION
A bit ugly to now have three separate bcftools images, however this release comes with htslib 1.21, which has an important fix for writing indexes with the `--write-index` option while not using multiple threads. 

See a Slack discussion of a bad index being written using bcftools 1.20 [here](https://centrepopgen.slack.com/archives/C082NA58R7S/p1744173388834459?thread_ts=1744163974.749869&cid=C082NA58R7S), and the htslib 1.21 release notes detailing the bugfix [here](https://github.com/samtools/htslib/releases/tag/1.21).
> Fix issues with on-the-fly indexing of VCF/BCF (bcftools --write-index) when not using multiple threads. 