### PR TITLE
Fix arg version format

### DIFF
--- a/.github/workflows/get_version.py
+++ b/.github/workflows/get_version.py
@@ -11,13 +11,25 @@ import sys
 def extract_version_from_file(file_path: str) -> str | None:
     """
     Extract the version from a Dockerfile by searching for a line like:
-    ENV VERSION=1.0.0
+    ENV VERSION=1.0
+    or
+    ARG VERSION=${VERSION:-1.0}
     """
     with open(file_path) as f:
         content = f.read()
-    pattern = re.compile(r'^\s*ENV\s+VERSION\s*=\s*([^\s]+)', re.MULTILINE)
-    match = pattern.search(content)
-    return match.group(1) if match else None
+    # Try ENV first
+    pattern_env = re.compile(r'^\s*ENV\s+VERSION\s*=\s*([^\s]+)', re.MULTILINE)
+    match_env = pattern_env.search(content)
+    if match_env:
+        return match_env.group(1)
+    # Now try ARG, with optional default after ':-'
+    pattern_arg = re.compile(
+        r'^\s*ARG\s+VERSION\s*=\s*\${VERSION:-(.+?)}', re.MULTILINE
+    )
+    match_arg = pattern_arg.search(content)
+    if match_arg:
+        return match_arg.group(1)
+    return None
 
 
 def get_next_version_tag(folder: str, version: str) -> str:

--- a/images/dummy/Dockerfile
+++ b/images/dummy/Dockerfile
@@ -1,4 +1,4 @@
 FROM docker.io/python:3.10-slim-bookworm
 
 # Adding a comment
-ENV VERSION=1.0
+ARG VERSION=${VERSION:-1.0}


### PR DESCRIPTION
This amends the `get_version` utility to recognise both formats of the version in a Dockerfile:

`ARG VERSION=${VERSION:-1.0}`
`ENV VERSION=1.0`