### PR TITLE
Install jq in stripy image

### DIFF
--- a/images/stripy/Dockerfile
+++ b/images/stripy/Dockerfile
@@ -77,7 +77,7 @@ RUN wget https://github.com/Illumina/REViewer/releases/download/${REVIEWER_VERSI
 # Install STRipy by cloning from git repo (the most updated version)
 RUN git clone https://gitlab.com/andreassh/stripy-pipeline.git \
     && cd stripy-pipeline  \
-    && git checkout ${VERSION} \
+    && git checkout $VERSION \
     && cd .. \
     && chmod 755 stripy-pipeline/batch.sh \
     && python3 -m pip install -r stripy-pipeline/requirements.txt

--- a/images/stripy/Dockerfile
+++ b/images/stripy/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     git \
     gnupg \
     gpg-agent \
+    jq \
     libbz2-dev \
     libcurl4-openssl-dev \
     libffi-dev \

--- a/images/stripy/Dockerfile
+++ b/images/stripy/Dockerfile
@@ -75,9 +75,10 @@ RUN wget https://github.com/Illumina/REViewer/releases/download/${REVIEWER_VERSI
     && ln -s /usr/local/bin/REViewer /usr/bin/REViewer
 
 # Install STRipy by cloning from git repo (the most updated version)
+ENV STRIPY_VERSION="v2.5"
 RUN git clone https://gitlab.com/andreassh/stripy-pipeline.git \
     && cd stripy-pipeline  \
-    && git checkout $VERSION \
+    && git checkout ${STRIPY_VERSION} \
     && cd .. \
     && chmod 755 stripy-pipeline/batch.sh \
     && python3 -m pip install -r stripy-pipeline/requirements.txt

--- a/images/stripy/Dockerfile
+++ b/images/stripy/Dockerfile
@@ -75,10 +75,9 @@ RUN wget https://github.com/Illumina/REViewer/releases/download/${REVIEWER_VERSI
     && ln -s /usr/local/bin/REViewer /usr/bin/REViewer
 
 # Install STRipy by cloning from git repo (the most updated version)
-ENV STRIPY_VERSION="v2.5"
 RUN git clone https://gitlab.com/andreassh/stripy-pipeline.git \
     && cd stripy-pipeline  \
-    && git checkout ${STRIPY_VERSION} \
+    && git checkout ${VERSION} \
     && cd .. \
     && chmod 755 stripy-pipeline/batch.sh \
     && python3 -m pip install -r stripy-pipeline/requirements.txt


### PR DESCRIPTION
Adds `jq` to the list of bash modules installed by `apt install`.

This is a useful bash library for json parsing, which is needed for updating the default `config.json` that comes with the stripy source code. See https://github.com/populationgenomics/production-pipelines/pull/1208

NOTE: This PR also hardcodes the stripy version "v2.5". This is because the `$VERSION` now evaluates to `"v2.5-1"` since the images overhaul, and this was preventing successful installation of the module. See comment [here](https://github.com/populationgenomics/images/pull/220#discussion_r2080913770) for an explanation.