### PR TITLE
Correction to VERSION override

### DIFF
--- a/.github/workflows/revamp.yaml
+++ b/.github/workflows/revamp.yaml
@@ -85,7 +85,6 @@ jobs:
       - name: 'build image'
         run: |
           docker build \
-          --build-arg VERSION=${{ matrix.tag }} \
           --tag ${{ env.IMAGES_PREFIX }}/${{ matrix.name }}:${{ matrix.tag }} \
           images/${{ matrix.name }}
 

--- a/.github/workflows/revamp_dev.yaml
+++ b/.github/workflows/revamp_dev.yaml
@@ -96,7 +96,6 @@ jobs:
       - name: 'build image with get_next_version'
         run: |
           docker build \
-          --build-arg VERSION=${{ matrix.tag }} \
           --tag ${{ env.IMAGES_PREFIX }}/${{ matrix.name }}:${{ matrix.tag }} \
           images/${{ matrix.name }}
 


### PR DESCRIPTION
Closes #224 

The VERSION in the Dockerfile is being used as a source of truth for the builder workflow when generating a new tag.

The tags are free-form, but the package Version number is not - we can't pass in an alternative VERSION argument at build time, we need the exact version to remain unchanged. See #224 