### PR TITLE
Fully activate revamped deployment actions workflows

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: Revamped Deploy with Versioning
+name: Deploy images
 on:
   push:
     branches:
@@ -11,7 +11,7 @@ permissions:
 env:
   PROJECT: 'cpg-common'
   DOCKER_PREFIX: 'australia-southeast1-docker.pkg.dev'
-  IMAGES_PREFIX: 'australia-southeast1-docker.pkg.dev/cpg-common/images-tmp' # use images-tmp for testing
+  IMAGES_PREFIX: 'australia-southeast1-docker.pkg.dev/cpg-common/images'
 
 jobs:
   get_next_version:

--- a/.github/workflows/deploy_dev.yaml
+++ b/.github/workflows/deploy_dev.yaml
@@ -1,4 +1,4 @@
-name: Revamped Deploy Dev Image
+name: Deploy dev image
 on:
   pull_request:
     types: [opened, synchronize]

--- a/.github/workflows/get_version.py
+++ b/.github/workflows/get_version.py
@@ -13,22 +13,20 @@ def extract_version_from_file(file_path: str) -> str | None:
     Extract the version from a Dockerfile by searching for a line like:
     ENV VERSION=1.0
     or
+    ARG VERSION=1.0
+    or
     ARG VERSION=${VERSION:-1.0}
     """
     with open(file_path) as f:
         content = f.read()
-    # Try ENV first
-    pattern_env = re.compile(r'^\s*ENV\s+VERSION\s*=\s*([^\s]+)', re.MULTILINE)
-    match_env = pattern_env.search(content)
-    if match_env:
-        return match_env.group(1)
-    # Now try ARG, with optional default after ':-'
-    pattern_arg = re.compile(
-        r'^\s*ARG\s+VERSION\s*=\s*\${VERSION:-(.+?)}', re.MULTILINE
-    )
-    match_arg = pattern_arg.search(content)
-    if match_arg:
-        return match_arg.group(1)
+
+    match = re.search(r'(ENV|ARG)\s+VERSION\s*=\s*([^\s]+)', content, re.MULTILINE)
+    if match:
+        value = match.group(2)
+        # Remove ${VERSION:- ... } if present
+        match = re.fullmatch(r'\${VERSION:-([^}]+)}', value)
+        return match.group(1) if match else value
+
     return None
 
 

--- a/README.md
+++ b/README.md
@@ -15,19 +15,16 @@ This is a BAD place for:
 Assuming you want to create an image for a tool called `mytool` of version `1.0.1`, add a folder called `images/mytool` with a `Dockerfile` file. Parametrise the `Dockerfile` by `${VERSION}` that will correspond to the version of your tool and the tag of your future image. For example, inside the `Dockerfile` you would have:
 
 ```Dockerfile
-ARG VERSION=${VERSION}
+ARG VERSION=1.0.1
 RUN pip install mytool==${VERSION}
 ```
 
-Then, add an entry into [`images.toml`](images.toml) with the name of your image matching the desired tag/version:
-
-```toml
-mytool = '1.0.1'
-```
-
 Finally, create a pull-request with your changes and assign someone to review it. Once merged, the GitHub CI will automatically build your image and push it into the `cpg-common` artifact registry.
+The image will be given a tag like `1.0.1-1`, `1.0.1-2`, etc, made up from your upstream tool version number with an automatically incremented sequence number suffix.
+This means that you will have a permanent tag to use to refer to each build of your image even when the upstream tool version has not changed.
 
-To update the tool version, modify the corresponding entry in TOML and create a pull request, CI will automatically rebuild the image.
+To update the tool version, modify the corresponding entry in the `ARG VERSION` line and create a pull request, CI will automatically rebuild the image.
+If the upstream tool is unchanged but you are modifying the packaging in the _Dockerfile_, just make those modifications and create a pull request. CI will increment the sequence number suffix automatically.
 
 ## Image moving scripts
 


### PR DESCRIPTION
Followup to PR #226, this activates the revamped workflows, in particular changing _revamp.yaml_ (now named _deploy.yaml_) to write to `images` instead of `images-tmp`. 🎉 

Update the _README.md_ documentation. There are already several Dockerfiles that use the `ARG VERSION=x.y.z` syntax (without `${VERSION:- … }` wrapped around the value), so we need to update _get_version.py_ to handle that too.

