### PR TITLE
Fix breaking validation step in dev deploys

### DIFF
--- a/.github/workflows/deploy_dev.yaml
+++ b/.github/workflows/deploy_dev.yaml
@@ -114,20 +114,20 @@ jobs:
       - name: 'checkout repo'
         uses: actions/checkout@v4
 
-      # - id: 'google-cloud-auth'
-      #   name: 'Authenticate to Google Cloud'
-      #   uses: 'google-github-actions/auth@v2'
-      #   with:
-      #     workload_identity_provider: 'projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
-      #     service_account: 'gh-images-dev-deployer@cpg-common.iam.gserviceaccount.com'
+      - id: 'google-cloud-auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'gh-images-dev-deployer@cpg-common.iam.gserviceaccount.com'
 
-      # - id: 'google-cloud-sdk-setup'
-      #   name: 'Set up Cloud SDK'
-      #   uses: google-github-actions/setup-gcloud@v2
+      - id: 'google-cloud-sdk-setup'
+        name: 'Set up Cloud SDK'
+        uses: google-github-actions/setup-gcloud@v2
 
-      # - name: 'gcloud docker auth'
-      #   run: |
-      #     gcloud auth configure-docker ${{ env.DOCKER_PREFIX }}
+      - name: 'gcloud docker auth'
+        run: |
+          gcloud auth configure-docker ${{ env.DOCKER_PREFIX }}
 
       - name: Validate and export inputs
         shell: bash

--- a/.github/workflows/deploy_dev.yaml
+++ b/.github/workflows/deploy_dev.yaml
@@ -114,20 +114,20 @@ jobs:
       - name: 'checkout repo'
         uses: actions/checkout@v4
 
-      - id: 'google-cloud-auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          workload_identity_provider: 'projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
-          service_account: 'gh-images-dev-deployer@cpg-common.iam.gserviceaccount.com'
+      # - id: 'google-cloud-auth'
+      #   name: 'Authenticate to Google Cloud'
+      #   uses: 'google-github-actions/auth@v2'
+      #   with:
+      #     workload_identity_provider: 'projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+      #     service_account: 'gh-images-dev-deployer@cpg-common.iam.gserviceaccount.com'
 
-      - id: 'google-cloud-sdk-setup'
-        name: 'Set up Cloud SDK'
-        uses: google-github-actions/setup-gcloud@v2
+      # - id: 'google-cloud-sdk-setup'
+      #   name: 'Set up Cloud SDK'
+      #   uses: google-github-actions/setup-gcloud@v2
 
-      - name: 'gcloud docker auth'
-        run: |
-          gcloud auth configure-docker ${{ env.DOCKER_PREFIX }}
+      # - name: 'gcloud docker auth'
+      #   run: |
+      #     gcloud auth configure-docker ${{ env.DOCKER_PREFIX }}
 
       - name: Validate and export inputs
         shell: bash
@@ -149,8 +149,8 @@ jobs:
             exit 1
           fi
 
-          # Validate CLI args
-          if [[ "$CLI_ARGS" =~ [;&|><`()$] ]]; then
+          # Validate CLI args (only if not empty)
+          if [[ -n "$CLI_ARGS" && "$CLI_ARGS" =~ [\;\&\|\>\<\`\(\)\$] ]]; then
             echo "❌ Unsafe characters in CLI args: $CLI_ARGS"
             exit 1
           fi


### PR DESCRIPTION
The validation steps in the dev deploy manual workflow were failing due to unescaped characters in the regex. This has now been fixed and a check has also been added to ensure empty docker cli args are accepted.