### PR TITLE
Update SAMtools build

### DIFF
--- a/images/samtools/Dockerfile
+++ b/images/samtools/Dockerfile
@@ -1,14 +1,40 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim AS base
 
-ENV MAMBA_ROOT_PREFIX /root/micromamba
-ENV PATH $MAMBA_ROOT_PREFIX/bin:$PATH
-ARG VERSION=${VERSION:-1.18}
+ENV VERSION=1.21
 
-RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+        libbz2-1.0 \
+        libcurl4 \
+        liblzma5 \
+        libncurses5-dev \
+        libssl3 \
+        zlib1g && \
     rm -r /var/lib/apt/lists/* && \
-    rm -r /var/cache/apt/* && \
-    wget -qO- https://conda.anaconda.org/conda-forge/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
-    mkdir ${MAMBA_ROOT_PREFIX} && \
-    micromamba install -y --prefix ${MAMBA_ROOT_PREFIX} -c bioconda -c conda-forge \
-    samtools=${VERSION} python=3.10 google-cloud-sdk dill && \
-    rm -r /root/micromamba/pkgs
+    rm -r /var/cache/apt/*
+
+# second stage - add compile-relevant tools, obtain release, install from release
+FROM base AS compiler
+RUN apt-get update && apt-get install -y \
+        bzip2 \
+        gcc \
+        libbz2-dev \
+        libcurl4-openssl-dev \
+        liblzma-dev \
+        libncurses5-dev \
+        libssl-dev \
+        make \
+        wget \
+        zlib1g-dev
+
+	# Install samtools
+RUN wget https://github.com/samtools/samtools/releases/download/${VERSION}/samtools-${VERSION}.tar.bz2 && \
+    tar -xf samtools-${VERSION}.tar.bz2 && \
+    cd samtools-${VERSION} && \
+    ./configure --enable-libcurl --enable-s3 --enable-gcs && \
+    make && \
+    make DESTDIR=/samtools_install install && \
+    make -C htslib-$VERSION DESTDIR=/samtools_install install
+
+FROM base
+COPY --from=compiler /samtools_install/usr/local/bin/* /usr/local/bin/


### PR DESCRIPTION
size reduction 1.8GB -> 172MB

This was a bit of a sidetrack, the mito/stripy images contain an old samtools... I thought it might be good to build a lean samtools image and use it as a base. In any case, the one we have is fat and gross, and this should is much more space efficient