### PR TITLE
Install procps in cpg_hail and multiqc

### DIFF
--- a/images/cpg_hail/Dockerfile
+++ b/images/cpg_hail/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
         gnupg \
         jq \
         openjdk-17-jdk-headless \
+        procps \
         rsync \
         software-properties-common \
         wget \

--- a/images/multiqc/Dockerfile
+++ b/images/multiqc/Dockerfile
@@ -2,4 +2,8 @@ FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.1
 
 ARG VERSION=${VERSION:-1.30}
 
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        procps
+
 RUN pip install multiqc==${VERSION}


### PR DESCRIPTION
Install `procps` in the cpg_hail image

- images using `cpg_hail` will need to update the version to match this one if they want procps to be included