### PR TITLE
Update to latest GATK version v4.6.2.0

### DIFF
--- a/images/gatk/Dockerfile
+++ b/images/gatk/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 ENV MAMBA_ROOT_PREFIX /root/micromamba
 ENV PATH $MAMBA_ROOT_PREFIX/bin:$PATH
-ARG VERSION=${VERSION:-4.2.6.1}
+ARG VERSION=${VERSION:-4.6.2.0}
 
 RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
     rm -r /var/lib/apt/lists/* && \


### PR DESCRIPTION
Version bump to use the latest release of GATK https://github.com/broadinstitute/gatk/releases