### PR TITLE
Prevent Exomiser 14.X using CADD

### DIFF
--- a/images/exomiser/template.yaml
+++ b/images/exomiser/template.yaml
@@ -42,7 +42,7 @@ analysis:
   # REMM is trained on non-coding regulatory regions
   # *WARNING* if you enable CADD or REMM ensure that you have downloaded and installed the CADD/REMM tabix files
   # and updated their location in the application.properties. Exomiser will not run without this.
-    pathogenicitySources: [ REVEL, MVP, CADD, REMM ]
+    pathogenicitySources: [ REVEL, MVP, ALPHA_MISSENSE ]
   # this is the standard exomiser order.
   # all steps are optional
     steps: [


### PR DESCRIPTION
These settings were recommended by correspondence. During the PR #258 (condensing the two Exomiser builds down to a single image) I failed to spot the change in `pathogenicitySources`. The configuration we want for v14+ is this (`REVEL, MVP, ALPHA_MISSENSE`) as we don't want to add CADD. AlphaMissense performs better, and has WAY less reference data required to set it up.

Example failure: https://batch.hail.populationgenomics.org.au/batches/632587/jobs/118