### PR TITLE
Using base image with Python for bcftools

### DIFF
--- a/images/bcftools/Dockerfile
+++ b/images/bcftools/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS base
+FROM python:3.11-bookworm-slim AS base
 
 ENV VERSION=1.22
 


### PR DESCRIPTION
Popgen is refactoring their codebase and requires bcftools to have access to python so that jobs can call scripts that use bcftools via python `subprocess`