### PR TITLE
Adding python to VEP110 Image

### DIFF
--- a/images/vep_110/Dockerfile
+++ b/images/vep_110/Dockerfile
@@ -58,6 +58,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         ca-certificates \
         git \
         libncurses5-dev \
+        python3 \
         wget \
     && curl https://raw.githubusercontent.com/Ensembl/UTRannotator/master/uORF_5UTR_GRCh38_PUBLIC.txt > ${UTR38} \
     && curl https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/110/pLI_values.txt > ${PLI_SCORES} \


### PR DESCRIPTION
The VEP annotation pipeline runs as a scatter job in the Popgen genomic atlas pipeline. Each job executes a small Python helper script inside the container to construct and dispatch the VEP command. The script uses only the standard library — no additional packages are required.
The current `vep_110` image does not include Python, causing jobs to fail with `python3: command not found`.

Change
Add a minimal Python 3 installation to the Dockerfile:
```
&& apt-get install -y --no-install-recommends \
build-essential \
ca-certificates \
git \
libncurses5-dev \
python3 \
wget \
```

No Python packages are installed beyond the interpreter itself, keeping the image size increase to a minimum.

### Context
The broader pipeline refactor is intentionally moving toward stages that call self-contained Python scripts as bash jobs, with paths and resources passed as arguments. This is partly motivated by keeping job logic decoupled from the pipeline framework, and to ease a potential future transition to Nextflow. The trade-off when using tool-specific images (like VEP) is that scripts and resources need to be localised — adding Python to the image resolves that for the VEP case.
