### PR TITLE
VNtyper image from cpg_hail_gcloud:0.2.137.cpg1-2

### DIFF
--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -22,15 +22,13 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     git checkout v${VERSION} && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir . && \
-    mkdir -p /vntyper/references && \
-    vntyper install-references --output-dir /vntyper/references --references hg38
+    vntyper install-references --output-dir /vntyper/reference --references hg38
 
 # Patch vntyper to use the CRAM_REFERENCE environment variable, necessary for compatibility with CPG's CRAM reference management
 RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \
       /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py
 
-# Create symlinks for vntyper and its references in the vntyper package install directory
-RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper && \
-    ln -s /vntyper/references /vntyper/reference
+# Create symlink for vntyper package install directory
+RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper
 
 WORKDIR /vntyper

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -7,4 +7,5 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     git checkout v${VERSION} && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir . && \
-    vntyper install-references --output-dir /vntyper/references --references hg38
+    mkdir -p /vntyper/references && \
+    vntyper install-references --output-dir /vntyper/references

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -6,5 +6,5 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     cd vntyper && \
     git checkout v${VERSION} && \
     pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir . && \
+    pip install . && \
     vntyper install-references -d /vntyper/references --references hg38

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -25,3 +25,8 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
 
 RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \
       /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py
+
+RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper && \
+    ln -s /vntyper/references /vntyper/reference
+
+WORKDIR /vntyper

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -7,3 +7,5 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     git checkout v${VERSION} && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir .
+
+RUN vntyper install-references -d /vntyper/references --references hg38

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -6,5 +6,5 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     cd vntyper && \
     git checkout v${VERSION} && \
     pip install --no-cache-dir --upgrade pip && \
-    pip install . && \
-    vntyper install-references -d /vntyper/references --references hg38
+    pip install --no-cache-dir . && \
+    vntyper install-references --output-dir /vntyper/references --references hg38

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -1,0 +1,9 @@
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2 AS base
+
+ARG VERSION=${VERSION:-2.0.3}
+
+RUN git clone https://github.com/hassansaei/vntyper.git && \
+    cd vntyper && \
+    git checkout v${VERSION} && \
+    pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir .

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -2,11 +2,18 @@ FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.1
 
 ARG VERSION=${VERSION:-2.0.3}
 
-RUN conda install -y -c bioconda -c conda-forge \
+ENV MAMBA_ROOT_PREFIX=/root/micromamba
+ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
+
+RUN apt-get update && apt-get install -y wget bzip2 && \
+    rm -rf /var/lib/apt/lists/* && \
+    wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
+    mkdir -p ${MAMBA_ROOT_PREFIX} && \
+    micromamba install -y --prefix ${MAMBA_ROOT_PREFIX} -c bioconda -c conda-forge \
         bwa=0.7.18 \
         samtools=1.20 \
-        fastp=0.23.4 \
-    && conda clean -afy
+        fastp=0.23.4 && \
+    rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
 
 RUN git clone https://github.com/hassansaei/vntyper.git && \
     cd vntyper && \

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -5,6 +5,7 @@ ARG VERSION=${VERSION:-2.0.3}
 ENV MAMBA_ROOT_PREFIX=/root/micromamba
 ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
 
+# Install micromamba and use it to install vntyper dependencies
 RUN apt-get update && apt-get install -y wget bzip2 && \
     rm -rf /var/lib/apt/lists/* && \
     wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
@@ -15,6 +16,7 @@ RUN apt-get update && apt-get install -y wget bzip2 && \
         fastp=0.23.4 && \
     rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
 
+# Install vntyper from source and download hg38 references
 RUN git clone https://github.com/hassansaei/vntyper.git && \
     cd vntyper && \
     git checkout v${VERSION} && \
@@ -23,9 +25,11 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     mkdir -p /vntyper/references && \
     vntyper install-references --output-dir /vntyper/references --references hg38
 
+# Patch vntyper to use the CRAM_REFERENCE environment variable, necessary for compatibility with CPG's CRAM reference management
 RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \
       /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py
 
+# Create symlinks for vntyper and its references in the vntyper package install directory
 RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper && \
     ln -s /vntyper/references /vntyper/reference
 

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -8,4 +8,4 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir . && \
     mkdir -p /vntyper/references && \
-    vntyper install-references --output-dir /vntyper/references
+    vntyper install-references --output-dir /vntyper/references --references hg38

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -2,6 +2,12 @@ FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.1
 
 ARG VERSION=${VERSION:-2.0.3}
 
+RUN conda install -y -c bioconda -c conda-forge \
+        bwa=0.7.18 \
+        samtools=1.20 \
+        fastp=0.23.4 \
+    && conda clean -afy
+
 RUN git clone https://github.com/hassansaei/vntyper.git && \
     cd vntyper && \
     git checkout v${VERSION} && \

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -6,6 +6,5 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     cd vntyper && \
     git checkout v${VERSION} && \
     pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir .
-
-RUN vntyper install-references -d /vntyper/references --references hg38
+    pip install --no-cache-dir . && \
+    vntyper install-references -d /vntyper/references --references hg38

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -22,3 +22,6 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     pip install --no-cache-dir . && \
     mkdir -p /vntyper/references && \
     vntyper install-references --output-dir /vntyper/references --references hg38
+
+RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \
+      /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py


### PR DESCRIPTION
New image that installs [VNtyper](https://github.com/hassansaei/VNtyper) v2.0.3

- Use Micromamba to install dependencies, namely `bwa v0.7.18` and `samtools v1.20`, ripped from [the Conda requirements](https://github.com/hassansaei/VNtyper/blob/main/conda/environment_vntyper.yml)
- Clone the repo install it by following [the README instructions](https://github.com/hassansaei/VNtyper/tree/main#using-pip)
- Install hg38 references, no need for hg19 for our workflows
- Make a minor update to the source code, which sets the CRAM reference to depend on an environment variable that we can inject via the pipeline. Without this, [the CRAM reference is hardcoded to be an empty string](https://github.com/hassansaei/VNtyper/blob/main/vntyper/scripts/fastq_bam_processing.py#L124). By letting it depend on an env variable, we can ensure the right reference fasta is used like this:
```python
    reference = hail_batch.fasta_res_group(batch_instance)

    job.command(f"""\
    export CRAM_REFERENCE={reference['base']}
    vntyper ...
    """)
```
- Create symlink for the vntyper dir, otherwise it doesn't know where to find the kestrel jar (see https://batch.hail.populationgenomics.org.au/batches/1128850/jobs/1)