### PR TITLE
Vntyper

### DIFF
--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -22,15 +22,13 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     git checkout v${VERSION} && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir . && \
-    mkdir -p /vntyper/references && \
-    vntyper install-references --output-dir /vntyper/references --references hg38
+    vntyper install-references --output-dir /vntyper/reference --references hg38
 
 # Patch vntyper to use the CRAM_REFERENCE environment variable, necessary for compatibility with CPG's CRAM reference management
 RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \
       /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py
 
-# Create symlinks for vntyper and its references in the vntyper package install directory
-RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper && \
-    ln -s /vntyper/references /vntyper/reference
+# Create symlink for vntyper package install directory
+RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper
 
 WORKDIR /vntyper

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y wget bzip2 && \
     micromamba install -y --prefix ${MAMBA_ROOT_PREFIX} -c bioconda -c conda-forge \
         bwa=0.7.18 \
         samtools=1.20 \
+        bcftools=1.21 \
         fastp=0.23.4 && \
     rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
 

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -49,4 +49,4 @@ RUN git clone https://github.com/berntpopp/adVNTR.git --branch enhanced_hmm /tmp
         python setup.py install && \
     rm -rf /tmp/adVNTR
 
-WORKDIR /vntype
+WORKDIR /vntyper

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -7,4 +7,5 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     git checkout v${VERSION} && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir . && \
-    vntyper install-references --output-dir /vntyper/references --references hg38
+    mkdir -p /vntyper/references && \
+    vntyper install-references --output-dir /vntyper/references

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -22,13 +22,6 @@ RUN git clone https://github.com/hassansaei/vntyper.git /tmp/vntyper-src && \
     cd /tmp/vntyper-src && \
     git checkout v${VERSION}
 
-RUN git clone https://github.com/berntpopp/adVNTR.git --branch enhanced_hmm /tmp/adVNTR && \
-    cd /tmp/adVNTR && \
-    micromamba run -n envadvntr env \
-        CFLAGS="-Wno-error=incompatible-pointer-types -Wno-error=int-conversion" \
-        python setup.py install && \
-    rm -rf /tmp/adVNTR
-
 # Install vntyper and download hg38 + advntr references
 RUN cd /tmp/vntyper-src && \
     pip install --no-cache-dir --upgrade pip && \

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -17,6 +17,15 @@ RUN apt-get update && apt-get install -y wget bzip2 && \
         fastp=0.23.4 && \
     rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
 
+# Install vntyper from source and download hg38 + advntr references
+RUN git clone https://github.com/hassansaei/vntyper.git /tmp/vntyper-src && \
+    cd /tmp/vntyper-src && \
+    git checkout v${VERSION} && \
+    pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir . && \
+    vntyper install-references --output-dir /vntyper/reference --references hg38 advntr && \
+    rm -rf /tmp/vntyper-src
+
 # Create the envadvntr conda environment for adVNTR (Python 2.7)
 COPY vntyper/conda/environment_envadvntr.yml /tmp/environment_envadvntr.yml
 RUN micromamba create -y -f /tmp/environment_envadvntr.yml && \
@@ -28,15 +37,6 @@ RUN git clone https://github.com/berntpopp/adVNTR.git --branch enhanced_hmm /tmp
     micromamba run -n envadvntr \
         bash -c 'CFLAGS="${CFLAGS:-} -Wno-error=incompatible-pointer-types -Wno-error=int-conversion" python setup.py install' && \
     rm -rf /tmp/adVNTR
-
-# Install vntyper from source and download hg38 + advntr references
-RUN git clone https://github.com/hassansaei/vntyper.git /tmp/vntyper-src && \
-    cd /tmp/vntyper-src && \
-    git checkout v${VERSION} && \
-    pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir . && \
-    vntyper install-references --output-dir /vntyper/reference --references hg38 advntr && \
-    rm -rf /tmp/vntyper-src
 
 # Patch vntyper to use the CRAM_REFERENCE environment variable
 RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -6,5 +6,5 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     cd vntyper && \
     git checkout v${VERSION} && \
     pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir . && \
+    pip install . && \
     vntyper install-references -d /vntyper/references --references hg38

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -26,12 +26,12 @@ RUN git clone https://github.com/hassansaei/vntyper.git /tmp/vntyper-src && \
 RUN cd /tmp/vntyper-src && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir . && \
-    vntyper install-references --output-dir /vntyper/reference --references hg38 advntr && \
+    vntyper install-references --output-dir /vntyper/reference --references hg38 vntr_db_advntr && \
     rm -rf /tmp/vntyper-src
 
 # Patch vntyper to use the CRAM_REFERENCE environment variable
 RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \
-        /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py
+    /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py
 
 # Create symlinks so vntyper's relative paths resolve
 RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper && \

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -25,3 +25,8 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
 
 RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \
       /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py
+
+RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper && \
+    ln -s /vntyper/references /vntyper/reference
+
+WORKDIR /vntyper

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -7,3 +7,5 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     git checkout v${VERSION} && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir .
+
+RUN vntyper install-references -d /vntyper/references --references hg38

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -37,4 +37,12 @@ RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['
 RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper && \
     ln -s ${MAMBA_ROOT_PREFIX}/bin/micromamba /usr/local/bin/mamba
 
+# Install adVNTR into a separate conda environment `envadvntr`
+RUN git clone https://github.com/berntpopp/adVNTR.git --branch enhanced_hmm /tmp/adVNTR && \
+    cd /tmp/adVNTR && \
+    micromamba run -n envadvntr env \
+        CFLAGS="-Wno-error=incompatible-pointer-types -Wno-error=int-conversion" \
+        python setup.py install && \
+    rm -rf /tmp/adVNTR
+
 WORKDIR /vntyper

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -22,6 +22,10 @@ RUN git clone https://github.com/hassansaei/vntyper.git /tmp/vntyper-src && \
     cd /tmp/vntyper-src && \
     git checkout v${VERSION}
 
+# Create the envadvntr conda environment (Python 2.7) from the vntyper source
+RUN micromamba create -y -f /tmp/vntyper-src/conda/environment_envadvntr.yml && \
+    rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
+
 # Install vntyper and download hg38 + advntr references
 RUN cd /tmp/vntyper-src && \
     pip install --no-cache-dir --upgrade pip && \
@@ -37,7 +41,7 @@ RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['
 RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper && \
     ln -s ${MAMBA_ROOT_PREFIX}/bin/micromamba /usr/local/bin/mamba
 
-# Install adVNTR into a separate conda environment `envadvntr`
+# Install adVNTR into the envadvntr environment
 RUN git clone https://github.com/berntpopp/adVNTR.git --branch enhanced_hmm /tmp/adVNTR && \
     cd /tmp/adVNTR && \
     micromamba run -n envadvntr env \
@@ -45,4 +49,4 @@ RUN git clone https://github.com/berntpopp/adVNTR.git --branch enhanced_hmm /tmp
         python setup.py install && \
     rm -rf /tmp/adVNTR
 
-WORKDIR /vntyper
+WORKDIR /vntype

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -39,7 +39,7 @@ RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['
 
 # Create symlinks so vntyper's relative paths resolve
 RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper && \
-    ln -s ${MAMBA_ROOT_PREFIX}/bin/micromamba /usr/local/bin/mamba
+    ln -s /usr/local/bin/micromamba /usr/local/bin/mamba
 
 # Install adVNTR into the envadvntr environment
 RUN git clone https://github.com/berntpopp/adVNTR.git --branch enhanced_hmm /tmp/adVNTR && \

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -17,19 +17,14 @@ RUN apt-get update && apt-get install -y wget bzip2 && \
         fastp=0.23.4 && \
     rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
 
-# Install vntyper from source and download hg38 + advntr references
+# Clone vntyper source
 RUN git clone https://github.com/hassansaei/vntyper.git /tmp/vntyper-src && \
     cd /tmp/vntyper-src && \
-    git checkout v${VERSION} && \
-    pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir . && \
-    vntyper install-references --output-dir /vntyper/reference --references hg38 advntr && \
-    rm -rf /tmp/vntyper-src
+    git checkout v${VERSION}
 
 # Create the envadvntr conda environment for adVNTR (Python 2.7)
-COPY vntyper/conda/environment_envadvntr.yml /tmp/environment_envadvntr.yml
-RUN micromamba create -y -f /tmp/environment_envadvntr.yml && \
-    rm -rf ${MAMBA_ROOT_PREFIX}/pkgs /tmp/environment_envadvntr.yml
+RUN micromamba create -y -f /tmp/vntyper-src/conda/environment_envadvntr.yml && \
+    rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
 
 # Install adVNTR into the envadvntr environment
 RUN git clone https://github.com/berntpopp/adVNTR.git --branch enhanced_hmm /tmp/adVNTR && \
@@ -38,9 +33,16 @@ RUN git clone https://github.com/berntpopp/adVNTR.git --branch enhanced_hmm /tmp
         bash -c 'CFLAGS="${CFLAGS:-} -Wno-error=incompatible-pointer-types -Wno-error=int-conversion" python setup.py install' && \
     rm -rf /tmp/adVNTR
 
+# Install vntyper and download hg38 + advntr references
+RUN cd /tmp/vntyper-src && \
+    pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir . && \
+    vntyper install-references --output-dir /vntyper/reference --references hg38 advntr && \
+    rm -rf /tmp/vntyper-src
+
 # Patch vntyper to use the CRAM_REFERENCE environment variable
 RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \
-    /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py
+        /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py
 
 # Create symlinks so vntyper's relative paths resolve
 RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper && \

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -8,7 +8,7 @@
   # Install micromamba and the main vntyper dependencies
   RUN apt-get update && apt-get install -y wget bzip2 && \
       rm -rf /var/lib/apt/lists/* && \
-      wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
+      wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/2.5.0/linux-64/micromamba-2.5.0-1.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
       mkdir -p ${MAMBA_ROOT_PREFIX} && \
       micromamba install -y --prefix ${MAMBA_ROOT_PREFIX} -c bioconda -c conda-forge \
           bwa=0.7.18 \

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -6,5 +6,5 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     cd vntyper && \
     git checkout v${VERSION} && \
     pip install --no-cache-dir --upgrade pip && \
-    pip install . && \
-    vntyper install-references -d /vntyper/references --references hg38
+    pip install --no-cache-dir . && \
+    vntyper install-references --output-dir /vntyper/references --references hg38

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -1,0 +1,9 @@
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2 AS base
+
+ARG VERSION=${VERSION:-2.0.3}
+
+RUN git clone https://github.com/hassansaei/vntyper.git && \
+    cd vntyper && \
+    git checkout v${VERSION} && \
+    pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir .

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -27,11 +27,8 @@ RUN micromamba create -y -f /tmp/vntyper-src/conda/environment_envadvntr.yml && 
     rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
 
 # Install adVNTR into the envadvntr environment
-RUN git clone https://github.com/berntpopp/adVNTR.git --branch enhanced_hmm /tmp/adVNTR && \
-    cd /tmp/adVNTR && \
-    micromamba run -n envadvntr \
-        bash -c 'CFLAGS="${CFLAGS:-} -Wno-error=incompatible-pointer-types -Wno-error=int-conversion" python setup.py install' && \
-    rm -rf /tmp/adVNTR
+RUN cd /tmp/vntyper-src/vntyper/dependencies/advntr && \
+    micromamba run -n envadvntr bash install_advntr.sh -o
 
 # Install vntyper and download hg38 + advntr references
 RUN cd /tmp/vntyper-src && \

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -2,11 +2,18 @@ FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.1
 
 ARG VERSION=${VERSION:-2.0.3}
 
-RUN conda install -y -c bioconda -c conda-forge \
+ENV MAMBA_ROOT_PREFIX=/root/micromamba
+ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
+
+RUN apt-get update && apt-get install -y wget bzip2 && \
+    rm -rf /var/lib/apt/lists/* && \
+    wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
+    mkdir -p ${MAMBA_ROOT_PREFIX} && \
+    micromamba install -y --prefix ${MAMBA_ROOT_PREFIX} -c bioconda -c conda-forge \
         bwa=0.7.18 \
         samtools=1.20 \
-        fastp=0.23.4 \
-    && conda clean -afy
+        fastp=0.23.4 && \
+    rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
 
 RUN git clone https://github.com/hassansaei/vntyper.git && \
     cd vntyper && \

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -5,6 +5,7 @@ ARG VERSION=${VERSION:-2.0.3}
 ENV MAMBA_ROOT_PREFIX=/root/micromamba
 ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
 
+# Install micromamba and use it to install vntyper dependencies
 RUN apt-get update && apt-get install -y wget bzip2 && \
     rm -rf /var/lib/apt/lists/* && \
     wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
@@ -15,6 +16,7 @@ RUN apt-get update && apt-get install -y wget bzip2 && \
         fastp=0.23.4 && \
     rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
 
+# Install vntyper from source and download hg38 references
 RUN git clone https://github.com/hassansaei/vntyper.git && \
     cd vntyper && \
     git checkout v${VERSION} && \
@@ -23,9 +25,11 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     mkdir -p /vntyper/references && \
     vntyper install-references --output-dir /vntyper/references --references hg38
 
+# Patch vntyper to use the CRAM_REFERENCE environment variable, necessary for compatibility with CPG's CRAM reference management
 RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \
       /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py
 
+# Create symlinks for vntyper and its references in the vntyper package install directory
 RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper && \
     ln -s /vntyper/references /vntyper/reference
 

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -8,4 +8,4 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir . && \
     mkdir -p /vntyper/references && \
-    vntyper install-references --output-dir /vntyper/references
+    vntyper install-references --output-dir /vntyper/references --references hg38

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -2,6 +2,12 @@ FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.1
 
 ARG VERSION=${VERSION:-2.0.3}
 
+RUN conda install -y -c bioconda -c conda-forge \
+        bwa=0.7.18 \
+        samtools=1.20 \
+        fastp=0.23.4 \
+    && conda clean -afy
+
 RUN git clone https://github.com/hassansaei/vntyper.git && \
     cd vntyper && \
     git checkout v${VERSION} && \

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -6,7 +6,7 @@ ENV MAMBA_ROOT_PREFIX=/root/micromamba
 ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
 
 # Install micromamba and the main vntyper dependencies
-RUN apt-get update && apt-get install -y wget bzip2 && \
+RUN apt-get update && apt-get install -y wget bzip2 gcc g++ && \
     rm -rf /var/lib/apt/lists/* && \
     wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/2.5.0/linux-64/micromamba-2.5.0-1.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
     mkdir -p ${MAMBA_ROOT_PREFIX} && \

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -6,6 +6,5 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     cd vntyper && \
     git checkout v${VERSION} && \
     pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir .
-
-RUN vntyper install-references -d /vntyper/references --references hg38
+    pip install --no-cache-dir . && \
+    vntyper install-references -d /vntyper/references --references hg38

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -22,13 +22,12 @@ RUN git clone https://github.com/hassansaei/vntyper.git /tmp/vntyper-src && \
     cd /tmp/vntyper-src && \
     git checkout v${VERSION}
 
-# Create the envadvntr conda environment for adVNTR (Python 2.7)
-RUN micromamba create -y -f /tmp/vntyper-src/conda/environment_envadvntr.yml && \
-    rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
-
-# Install adVNTR into the envadvntr environment
-RUN cd /tmp/vntyper-src/vntyper/dependencies/advntr && \
-    micromamba run -n envadvntr bash install_advntr.sh -o
+RUN git clone https://github.com/berntpopp/adVNTR.git --branch enhanced_hmm /tmp/adVNTR && \
+    cd /tmp/adVNTR && \
+    micromamba run -n envadvntr env \
+        CFLAGS="-Wno-error=incompatible-pointer-types -Wno-error=int-conversion" \
+        python setup.py install && \
+    rm -rf /tmp/adVNTR
 
 # Install vntyper and download hg38 + advntr references
 RUN cd /tmp/vntyper-src && \

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -1,35 +1,49 @@
-FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2 AS base
+  FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2 AS base
 
-ARG VERSION=${VERSION:-2.0.3}
+  ARG VERSION=2.0.3
 
-ENV MAMBA_ROOT_PREFIX=/root/micromamba
-ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
+  ENV MAMBA_ROOT_PREFIX=/root/micromamba
+  ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
 
-# Install micromamba and use it to install vntyper dependencies
-RUN apt-get update && apt-get install -y wget bzip2 && \
-    rm -rf /var/lib/apt/lists/* && \
-    wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
-    mkdir -p ${MAMBA_ROOT_PREFIX} && \
-    micromamba install -y --prefix ${MAMBA_ROOT_PREFIX} -c bioconda -c conda-forge \
-        bwa=0.7.18 \
-        samtools=1.20 \
-        bcftools=1.21 \
-        fastp=0.23.4 && \
-    rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
+  # Install micromamba and the main vntyper dependencies
+  RUN apt-get update && apt-get install -y wget bzip2 && \
+      rm -rf /var/lib/apt/lists/* && \
+      wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
+      mkdir -p ${MAMBA_ROOT_PREFIX} && \
+      micromamba install -y --prefix ${MAMBA_ROOT_PREFIX} -c bioconda -c conda-forge \
+          bwa=0.7.18 \
+          samtools=1.20 \
+          bcftools=1.21 \
+          fastp=0.23.4 && \
+      rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
 
-# Install vntyper from source and download hg38 references
-RUN git clone https://github.com/hassansaei/vntyper.git && \
-    cd vntyper && \
-    git checkout v${VERSION} && \
-    pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir . && \
-    vntyper install-references --output-dir /vntyper/reference --references hg38
+  # Create the envadvntr conda environment for adVNTR (Python 2.7)
+  COPY vntyper/conda/environment_envadvntr.yml /tmp/environment_envadvntr.yml
+  RUN micromamba create -y -f /tmp/environment_envadvntr.yml && \
+      rm -rf ${MAMBA_ROOT_PREFIX}/pkgs /tmp/environment_envadvntr.yml
 
-# Patch vntyper to use the CRAM_REFERENCE environment variable, necessary for compatibility with CPG's CRAM reference management
-RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \
-      /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py
+  # Install adVNTR into the envadvntr environment
+  RUN git clone https://github.com/berntpopp/adVNTR.git --branch enhanced_hmm /tmp/adVNTR && \
+      cd /tmp/adVNTR && \
+      micromamba run -n envadvntr \
+          bash -c 'CFLAGS="${CFLAGS:-} -Wno-error=incompatible-pointer-types -Wno-error=int-conversion" python setup.py install' && \
+      rm -rf /tmp/adVNTR
 
-# Create symlink for vntyper package install directory
-RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper
+  # Install vntyper from source and download hg38 + advntr references
+  RUN git clone https://github.com/hassansaei/vntyper.git /tmp/vntyper-src && \
+      cd /tmp/vntyper-src && \
+      git checkout v${VERSION} && \
+      pip install --no-cache-dir --upgrade pip && \
+      pip install --no-cache-dir . && \
+      vntyper install-references --output-dir /vntyper/reference --references hg38 advntr && \
+      rm -rf /tmp/vntyper-src
 
-WORKDIR /vntyper
+  # Patch vntyper to use the CRAM_REFERENCE environment variable
+  RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \
+        /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py
+
+  # Create symlinks so vntyper's relative paths resolve
+  RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper && \
+      ln -s ${MAMBA_ROOT_PREFIX}/bin/micromamba /usr/local/bin/mamba
+
+  WORKDIR /vntyper

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -22,3 +22,6 @@ RUN git clone https://github.com/hassansaei/vntyper.git && \
     pip install --no-cache-dir . && \
     mkdir -p /vntyper/references && \
     vntyper install-references --output-dir /vntyper/references --references hg38
+
+RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \
+      /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py

--- a/images/vntyper/Dockerfile
+++ b/images/vntyper/Dockerfile
@@ -1,49 +1,49 @@
-  FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2 AS base
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2 AS base
 
-  ARG VERSION=2.0.3
+ARG VERSION=2.0.3
 
-  ENV MAMBA_ROOT_PREFIX=/root/micromamba
-  ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
+ENV MAMBA_ROOT_PREFIX=/root/micromamba
+ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
 
-  # Install micromamba and the main vntyper dependencies
-  RUN apt-get update && apt-get install -y wget bzip2 && \
-      rm -rf /var/lib/apt/lists/* && \
-      wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/2.5.0/linux-64/micromamba-2.5.0-1.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
-      mkdir -p ${MAMBA_ROOT_PREFIX} && \
-      micromamba install -y --prefix ${MAMBA_ROOT_PREFIX} -c bioconda -c conda-forge \
-          bwa=0.7.18 \
-          samtools=1.20 \
-          bcftools=1.21 \
-          fastp=0.23.4 && \
-      rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
+# Install micromamba and the main vntyper dependencies
+RUN apt-get update && apt-get install -y wget bzip2 && \
+    rm -rf /var/lib/apt/lists/* && \
+    wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/2.5.0/linux-64/micromamba-2.5.0-1.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
+    mkdir -p ${MAMBA_ROOT_PREFIX} && \
+    micromamba install -y --prefix ${MAMBA_ROOT_PREFIX} -c bioconda -c conda-forge \
+        bwa=0.7.18 \
+        samtools=1.20 \
+        bcftools=1.21 \
+        fastp=0.23.4 && \
+    rm -rf ${MAMBA_ROOT_PREFIX}/pkgs
 
-  # Create the envadvntr conda environment for adVNTR (Python 2.7)
-  COPY vntyper/conda/environment_envadvntr.yml /tmp/environment_envadvntr.yml
-  RUN micromamba create -y -f /tmp/environment_envadvntr.yml && \
-      rm -rf ${MAMBA_ROOT_PREFIX}/pkgs /tmp/environment_envadvntr.yml
+# Create the envadvntr conda environment for adVNTR (Python 2.7)
+COPY vntyper/conda/environment_envadvntr.yml /tmp/environment_envadvntr.yml
+RUN micromamba create -y -f /tmp/environment_envadvntr.yml && \
+    rm -rf ${MAMBA_ROOT_PREFIX}/pkgs /tmp/environment_envadvntr.yml
 
-  # Install adVNTR into the envadvntr environment
-  RUN git clone https://github.com/berntpopp/adVNTR.git --branch enhanced_hmm /tmp/adVNTR && \
-      cd /tmp/adVNTR && \
-      micromamba run -n envadvntr \
-          bash -c 'CFLAGS="${CFLAGS:-} -Wno-error=incompatible-pointer-types -Wno-error=int-conversion" python setup.py install' && \
-      rm -rf /tmp/adVNTR
+# Install adVNTR into the envadvntr environment
+RUN git clone https://github.com/berntpopp/adVNTR.git --branch enhanced_hmm /tmp/adVNTR && \
+    cd /tmp/adVNTR && \
+    micromamba run -n envadvntr \
+        bash -c 'CFLAGS="${CFLAGS:-} -Wno-error=incompatible-pointer-types -Wno-error=int-conversion" python setup.py install' && \
+    rm -rf /tmp/adVNTR
 
-  # Install vntyper from source and download hg38 + advntr references
-  RUN git clone https://github.com/hassansaei/vntyper.git /tmp/vntyper-src && \
-      cd /tmp/vntyper-src && \
-      git checkout v${VERSION} && \
-      pip install --no-cache-dir --upgrade pip && \
-      pip install --no-cache-dir . && \
-      vntyper install-references --output-dir /vntyper/reference --references hg38 advntr && \
-      rm -rf /tmp/vntyper-src
+# Install vntyper from source and download hg38 + advntr references
+RUN git clone https://github.com/hassansaei/vntyper.git /tmp/vntyper-src && \
+    cd /tmp/vntyper-src && \
+    git checkout v${VERSION} && \
+    pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir . && \
+    vntyper install-references --output-dir /vntyper/reference --references hg38 advntr && \
+    rm -rf /tmp/vntyper-src
 
-  # Patch vntyper to use the CRAM_REFERENCE environment variable
-  RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \
-        /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py
+# Patch vntyper to use the CRAM_REFERENCE environment variable
+RUN sed -i 's|cram_ref_option = ""|cram_ref_option = f"--reference {os.environ['"'"'CRAM_REFERENCE'"'"']}" if os.environ.get("CRAM_REFERENCE") else ""|' \
+    /usr/local/lib/python3.11/site-packages/vntyper/scripts/fastq_bam_processing.py
 
-  # Create symlinks so vntyper's relative paths resolve
-  RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper && \
-      ln -s ${MAMBA_ROOT_PREFIX}/bin/micromamba /usr/local/bin/mamba
+# Create symlinks so vntyper's relative paths resolve
+RUN ln -s /usr/local/lib/python3.11/site-packages/vntyper /vntyper/vntyper && \
+    ln -s ${MAMBA_ROOT_PREFIX}/bin/micromamba /usr/local/bin/mamba
 
-  WORKDIR /vntyper
+WORKDIR /vntyper


### PR DESCRIPTION
Update the VNtyper image to install advntr

- Install `gcc` and `g++` for the advntr install
- Use Micromamba 2.5.0 instead of ancient 0.8.2
- Also install bcftools to suppress warnings and allow compressed vcf outputs
- Download the advntr db references during the `install-references` command to allow for using code-advntr tool
- Install adVNTR and its dependencies into a separate conda env called `envadvntr` - this tool uses python 2 and the vntyper pipeline requires the separate environment
  - Borrow some code from the vntyper `install_advntr.sh` shell script to handle how newer GCC versions compile C code - the shell script doesn't work out of the box due to requiring `conda activate` commands, so install the env using micromamba directly 