### PR TITLE
cpg_hail image include openjdk-11

### DIFF
--- a/images/cpg_hail/Dockerfile
+++ b/images/cpg_hail/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
         git \
         gnupg \
         jq \
+        openjdk-11-jre-headless \
         openjdk-17-jre-headless \
         procps \
         rsync \

--- a/images/cpg_hail/Dockerfile
+++ b/images/cpg_hail/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
         git \
         gnupg \
         jq \
-        openjdk-11-jre-headless \
+        openjdk-11-jdk-headless \
         openjdk-17-jre-headless \
         procps \
         rsync \


### PR DESCRIPTION
Fix to #297, include both `openjdk-11-jdk-headless` and `openjdk-17-jre-headless` in the apt-get installs. Thanks for catching on that PR @jmarshall 