### PR TITLE
Cpg hail gcloud 0.2.138

### DIFF
--- a/images/cpg_hail_gcloud/Dockerfile
+++ b/images/cpg_hail_gcloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail:0.2.138.cpg1-1
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail:0.2.138.cpg1-2
 
 # this is the installation code direct from google
 # https://cloud.google.com/sdk/docs/install#deb

--- a/images/cpg_hail_gcloud/Dockerfile
+++ b/images/cpg_hail_gcloud/Dockerfile
@@ -11,4 +11,4 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
     rm -r /var/lib/apt/lists/* && \
     rm -r /var/cache/apt/*
 
-ARG VERSION=0.2.137.cpg1
+ARG VERSION=0.2.138.cpg1

--- a/images/cpg_hail_gcloud/Dockerfile
+++ b/images/cpg_hail_gcloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail:0.2.137.cpg1-2
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail:0.2.138.cpg1-1
 
 # this is the installation code direct from google
 # https://cloud.google.com/sdk/docs/install#deb


### PR DESCRIPTION
Update the `cpg_hail_gcloud` image to use the `0.2.138.cpg1` tag following the new Hail release and the updating of the `cpg_hail` image in #297 & #298