### PR TITLE
Switch KING image to bioconda install

### DIFF
--- a/images/king/Dockerfile
+++ b/images/king/Dockerfile
@@ -1,25 +1,14 @@
-FROM python:3.11-slim-bookworm
+FROM debian:bullseye-slim
 
+ENV MAMBA_ROOT_PREFIX=/root/micromamba
+ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
 ARG VERSION=2.3.2
-ENV VERSION=${VERSION}
-LABEL maintainer="Population Genomics Team"
-LABEL version="${VERSION}"
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    wget \
-    ca-certificates \
-    libquadmath0 \
-    libgomp1 \
-    && rm -rf /var/lib/apt/lists/*
-
-# KING upstream URL pattern strips dots from the version (e.g. 2.3.2 -> 232).
-# Browser User-Agent + retries: kingrelatedness.com filters the default wget UA
-# from some networks (notably CI runners), returning HTTP errors.
-RUN URL_VERSION=$(echo "${VERSION}" | tr -d '.') \
-    && wget --tries=3 --timeout=60 \
-        --user-agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36" \
-        "https://www.kingrelatedness.com/executables/Linux-king${URL_VERSION}.tar.gz" \
-        -O /tmp/king.tar.gz \
-    && tar -xzf /tmp/king.tar.gz -C /usr/local/bin king \
-    && chmod +x /usr/local/bin/king \
-    && rm /tmp/king.tar.gz
+RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
+    rm -r /var/lib/apt/lists/* && \
+    rm -r /var/cache/apt/* && \
+    wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
+    mkdir ${MAMBA_ROOT_PREFIX} && \
+    micromamba install -y --prefix ${MAMBA_ROOT_PREFIX} -c bioconda -c conda-forge \
+    king=${VERSION} && \
+    rm -r /root/micromamba/pkgs


### PR DESCRIPTION
## Summary

Replaces the wget-based KING install (merged in #300) with a micromamba + bioconda install, mirroring the pattern used by `bedtools`, `bwa`, `dragmap`, and `gcta`.

## Why

The post-merge `deploy.yaml` run for #300 ([`25717398785`](https://github.com/populationgenomics/images/actions/runs/25717398785)) failed at the `wget` step with HTTP 403 Forbidden from `kingrelatedness.com`. Reproducing locally confirmed the block is IP-based filtering against GitHub Actions runner ranges, not a User-Agent check — the User-Agent + retries patch in `9296ce0` did not help. As a result, `cpg-common/images/king:2.3.2-1` was never published, blocking downstream pipeline work in `popgen-genotyping`.

[bioconda ships `king=2.3.2` for `linux-64`](https://anaconda.org/bioconda/king/files), which bypasses the IP-filtered upstream entirely.

## Changes

- `images/king/Dockerfile`: rewrite from `python:3.11-slim-bookworm` + `wget` to `debian:bullseye-slim` + micromamba pinned at 0.8.2 (same pin used across all sibling micromamba Dockerfiles).
- Cleaner `ENV key=value` syntax and a plain `ARG VERSION=2.3.2` default — build emits zero BuildKit warnings.
- `--build-arg VERSION=…` still works for non-default builds.

## Verification

- Local build (`docker build --platform linux/amd64 -t king:bioconda-test images/king/`) succeeds in ~125s, image is 208 MB, zero BuildKit warnings.
- Binary smoke test: `KING 2.3.2 - (c) 2010-2023 Wei-Min Chen` banner prints; `--ibdseg`, `--cpus`, `--prefix` flags all listed.
- `--build-arg VERSION=2.2.4` override produces a distinct image with the older `king-2.2.4-hd03093a_2` bioconda package linked. *(Note: that particular bioconda recipe ships a binary that self-reports as `KING 2.2.7` — recipe-level mislabelling, not relevant to our 2.3.2 production pin.)*

## Test plan

- [ ] Merge → confirm `deploy.yaml` succeeds on `main`
- [ ] Confirm `australia-southeast1-docker.pkg.dev/cpg-common/images/king:2.3.2-<seq>` is published
- [ ] Smoke-test the published image: `docker run --rm <image> king` should print the 2.3.2 banner