### PR TITLE
Bump to 0.2.138.cpg2

### DIFF
--- a/images/cpg_hail/Dockerfile
+++ b/images/cpg_hail/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=0.2.138.cpg1
+ARG VERSION=0.2.138.cpg2
 
 FROM python:3.11-slim-bullseye AS basic
 
@@ -14,7 +14,6 @@ RUN apt-get update && \
         gnupg \
         jq \
         openjdk-11-jdk-headless \
-        openjdk-17-jre-headless \
         procps \
         rsync \
         software-properties-common \
@@ -35,7 +34,8 @@ RUN apt-get update && \
         gcc \
         libfontconfig \
         liblapack3 \
-        libopenblas-dev && \
+        libopenblas-dev \
+        openjdk-17-jre-headless && \
     rm -r /var/lib/apt/lists/* && \
     rm -r /var/cache/apt/*
 
@@ -47,8 +47,7 @@ RUN pip --no-cache-dir install \
     cd hail && \
     # Generate a Wheel, but don't install it in this layer
     # DEPLOY_REMOTE avoids a dev suffix being appended to dataproc initialization paths.
-    make wheel DEPLOY_REMOTE=1 HAIL_BUILD_MODE=Release && \
-    DEBIAN_FRONTEND=noninteractive apt-get purge -y openjdk-17-jre-headless
+    make wheel DEPLOY_REMOTE=1 HAIL_BUILD_MODE=Release
 
 FROM basic AS installer
 


### PR DESCRIPTION
Rebuild with reduced parallelism as a workaround for https://centrepopgen.slack.com/archives/C030X7WGFCL/p1779660592497319

Also only install JRE 17 on the builder. And now that we only install it on the builder layer, we don't need to worry about uninstalling openjdk-17-jre-headless.