### PR TITLE
Candidate for a NextFlow base image

### DIFF
--- a/images/nf_base/Dockerfile
+++ b/images/nf_base/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.11-slim-trixie AS base
+
+ARG VERSION=0.1.0
+
+LABEL \
+  version="v${VERSION}" \
+  description="CPG NextFlow Base Image"
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Australia/Sydney
+
+# Run update and install generic core packages
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        bzip2 \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        procps \
+        wget && \
+    rm -r /var/lib/apt/lists/* && \
+    rm -r /var/cache/apt/*
+
+RUN pip install \
+    metamist \
+    cpg-utils \

--- a/images/nf_base/Dockerfile
+++ b/images/nf_base/Dockerfile
@@ -23,6 +23,6 @@ RUN apt-get update -y && \
     rm -r /var/lib/apt/lists/* && \
     rm -r /var/cache/apt/*
 
-RUN pip install \
+RUN pip install --no-cache-dir \
     metamist \
     cpg-utils \


### PR DESCRIPTION
See title - an image containing core basics for building specialist NF images on.

Contains: 
- slim python base, on Debian Trixie (latest stable release)
- basic compilation and authentication packages
- git, curl, wget for sourcing further installs
- procps (essential for nextflow job monitoring)

Also contains two python packages:
- metamist for registering analyses and querying during workflow setup. Registering analyses/metamist POSTs are the important part here, as the same stage generating an output file should generate the corresponding record(s), which requires a single container containing both the functional tool and the metamist package.
- cpg-utils for basic path utilities

2 observations here...

* `metamist` has cpg-utils as a dependency, so putting `cpg-utils` in the pip install is about clarity; it would be installed anyway

* `cpg-utils` contains hail methods, but doesn't have hail as a dependency. This means a `pip install cpg-utils` doesn't install hail (good, hail is huge), but also big chunks of the cpg-utils package won't work out of the box:

```
╰─➤  docker run -it nf_base:0.1.0 bash
root@1f046645e17d:/# pip show hail
WARNING: Package(s) not found: hail
root@1f046645e17d:/# python                                                                                                                                                                                                                                                                                                                                                                                                                 
Python 3.11.15 (main, May 19 2026, 23:49:45) [GCC 14.2.0] on linux
>>> import cpg_utils
>>> from cpg_utils import hail_batch
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.11/site-packages/cpg_utils/hail_batch.py", line 18, in <module>
    import hail as hl
ModuleNotFoundError: No module named 'hail'
```

Possibly not an issue, as any derived image being used for hail should explicitly install hail, and ideally a fixed version of Hail, but worth noting. 