### PR TITLE
Update to VerifyBamID, and much smaller overall image

### DIFF
--- a/images/verifybamid/Dockerfile
+++ b/images/verifybamid/Dockerfile
@@ -1,14 +1,55 @@
-FROM debian:buster-slim
+# In this image we do not include the R-based plot scripts.
+FROM ubuntu:20.04 AS build
 
-ENV MAMBA_ROOT_PREFIX /root/micromamba
-ENV PATH $MAMBA_ROOT_PREFIX/bin:$PATH
-ARG VERSION=${VERSION:-2.0.1}
+# Set noninterative mode
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LD_LIBRARY_PATH="/usr/local/lib"
 
-RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
-    rm -r /var/lib/apt/lists/* && \
-    rm -r /var/cache/apt/* && \
-    wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
-    mkdir ${MAMBA_ROOT_PREFIX} && \
-    micromamba install -y --prefix ${MAMBA_ROOT_PREFIX} -c bioconda -c conda-forge \
-    verifybamid2=${VERSION} google-cloud-sdk && \
-    rm -r /root/micromamba/pkgs
+ARG HTSLIB_VERSION="1.23.1"
+ARG VERSION="v2.0.3"
+
+# apt update and install build requirements
+RUN apt-get update \
+     && apt-get install -y \
+        build-essential \
+        cmake \
+        g++ \
+        git \
+        wget \
+        libbz2-dev=1.0.8-2 \
+        libcurl4-openssl-dev \
+        zlib1g-dev \
+        liblzma-dev
+
+# Compile htslib
+WORKDIR /deps
+RUN wget -q https://github.com/samtools/htslib/releases/download/${HTSLIB_VERSION}/htslib-${HTSLIB_VERSION}.tar.bz2 \
+    && tar -xf htslib-${HTSLIB_VERSION}.tar.bz2 \
+    && mv htslib-${HTSLIB_VERSION} htslib
+
+WORKDIR /deps/htslib
+RUN autoheader; autoconf; ./configure --prefix=/usr/local/ \
+    && make && make install
+
+# Compile VerifyBamID. Version ${VERSION}
+WORKDIR /
+RUN git clone https://github.com/Griffan/VerifyBamID.git && \
+    cd VerifyBamID && \
+    git checkout ${VERSION}
+WORKDIR /VerifyBamID/build
+RUN cmake .. && \
+    make && \
+    make test
+
+# Final image
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt update && apt install -y \
+        libgomp1 \
+        libcurl4-openssl-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /VerifyBamID/bin/VerifyBamID /usr/local/bin/
+COPY --from=build /usr/local/lib/ /usr/local/lib/

--- a/images/verifybamid/Dockerfile
+++ b/images/verifybamid/Dockerfile
@@ -5,8 +5,8 @@ FROM ubuntu:20.04 AS build
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 
-ARG HTSLIB_VERSION="1.23.1"
-ARG VERSION="v2.0.3"
+ARG HTSLIB_VERSION=1.23.1
+ARG VERSION=v2.0.3
 
 # apt update and install build requirements
 RUN apt-get update \

--- a/images/verifybamid/Dockerfile
+++ b/images/verifybamid/Dockerfile
@@ -37,7 +37,11 @@ RUN git clone https://github.com/Griffan/VerifyBamID.git && \
     cd VerifyBamID && \
     git checkout ${VERSION}
 WORKDIR /VerifyBamID/build
-RUN cmake .. && \
+
+# -fsigned-char: VerifyBamID's genotype-missing sentinel relies on `char`
+# being signed (default on x86_64 but not on aarch64), which otherwise
+# breaks missing-genotype detection and fails testReadVcf.
+RUN cmake -DCMAKE_C_FLAGS=-fsigned-char -DCMAKE_CXX_FLAGS=-fsigned-char .. && \
     make && \
     make test
 


### PR DESCRIPTION
(not sure if PopGen use this image)

n.b. this includes a fix that might be worth upstreaming - the cmake & test loop built into the upstream dockerfile was broken on my local machine, and after a lot of back and forth it looks like a platform-specific failure mode. From Claude:

```
- On x86_64, char defaults to signed, so the code's -1 sentinel (missing genotype) already worked correctly there — that's likely why this Dockerfile worked before.          
  - On aarch64 (e.g., your Mac's Docker), char defaults to unsigned per the ARM ABI, which silently turned the -1 sentinel into 255, breaking missing-genotype detection.       
  - -fsigned-char is a standard GCC/Clang flag supported on all architectures (x86_64, aarch64, etc.) that explicitly forces char to be signed, overriding whatever the platform
  default is.                                                                                                                                                                   
                                                                                                                                                                                
  So adding this flag makes the build behave identically on both amd64 and arm64 — it's not a workaround specific to your machine, it fixes a genuine latent portability bug in 
  the upstream code that only happened to be masked on x86_64.
```


I'm ambivalent about upstreaming, nobody is productionising workflows on mac, and this repo is barely maintained, but this change brings the docker image size down 90%, whilst updating the version and upgrading HTSlib from 1.11 -> 1.23.1