### PR TITLE
Update bcftools to 1.24

### DIFF
--- a/images/bcftools/Dockerfile
+++ b/images/bcftools/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim AS base
 
-ENV VERSION=1.23.1
+ENV VERSION=1.24
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Creates a new BCFtools image for the 1.24 tool version