### PR TITLE
Update image path 

### DIFF
--- a/scripts/copy_gatk_eph_image.sh
+++ b/scripts/copy_gatk_eph_image.sh
@@ -12,4 +12,4 @@ IMAGE_NAME="gatk_federate_svs"
 IMAGE_TAG="53b4f16a7"
 
 gcloud auth configure-docker australia-southeast1-docker.pkg.dev
-skopeo copy ${SOURCE_IMAGE} docker://australia-southeast1-docker.pkg.dev/tenk10k-sv/images/${IMAGE_NAME}:${IMAGE_TAG}
+skopeo copy ${SOURCE_IMAGE} docker://australia-southeast1-docker.pkg.dev/tenk10k-sv/images/sv/${IMAGE_NAME}:${IMAGE_TAG}

--- a/scripts/copy_gatk_eph_image.sh
+++ b/scripts/copy_gatk_eph_image.sh
@@ -12,4 +12,4 @@ IMAGE_NAME="gatk_federate_svs"
 IMAGE_TAG="53b4f16a7"
 
 gcloud auth configure-docker australia-southeast1-docker.pkg.dev
-skopeo copy ${SOURCE_IMAGE} docker://australia-southeast1-docker.pkg.dev/cpg-common/images/${IMAGE_NAME}:${IMAGE_TAG}
+skopeo copy ${SOURCE_IMAGE} docker://australia-southeast1-docker.pkg.dev/tenk10k-sv/images/${IMAGE_NAME}:${IMAGE_TAG}


### PR DESCRIPTION
I think the terra account does not have access to `cpg-common` based on the error message in: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1786580947459439. 

Would like to rebuild in `australia-southeast1-docker.pkg.dev/tenk10k-sv/images/sv` (directory where all the other images that Terra pulls from are stored in)