### PR TITLE
bumping rbceq2 to v 2.4.3

### DIFF
--- a/images/rbceq2/Dockerfile
+++ b/images/rbceq2/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y procps && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION=${VERSION:-2.4.1}
+ARG VERSION=${VERSION:-2.4.3}
 RUN pip install --no-cache-dir "rbceq2==${VERSION}"
 
 # Standard entrypoint (though Nextflow overrides this)


### PR DESCRIPTION
bumping rbceq2 to v 2.4.3, released Jul 27, 2026.
NB: database is at version v2.5.0