### PR TITLE
Bump plink2 to alpha7 build 20260808

### DIFF
--- a/images/plink/Dockerfile
+++ b/images/plink/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.11-slim-bookworm
 
 # Build metadata
-ENV VERSION=1.9-20250819-PLINK-2.0-20260228
+ENV VERSION=1.9-20250819-PLINK-2.0-20260808
 LABEL maintainer="Population Genomics Team"
 LABEL version="${VERSION}"
 
@@ -22,21 +22,21 @@ RUN wget -q https://s3.amazonaws.com/plink1-assets/plink_linux_x86_64_20250819.z
     && mv /tmp/plink1/plink /usr/local/bin/plink1.9 \
     && rm -rf plink1.zip /tmp/plink1
 
-# 2. Download and install PLINK 2.0 variants (Build 20260228)
+# 2. Download and install PLINK 2.0 variants (Build 20260808)
 # Intel AVX2
-RUN wget -q https://s3.amazonaws.com/plink2-assets/alpha6/plink2_linux_avx2_20260228.zip -O intel.zip \
+RUN wget -q https://s3.amazonaws.com/plink2-assets/alpha7/plink2_linux_avx2_20260808.zip -O intel.zip \
     && unzip -q intel.zip -d /tmp/intel \
     && mv /tmp/intel/plink2 /usr/local/bin/variants/plink2_intel_avx2 \
     && rm -rf intel.zip /tmp/intel
 
 # AMD AVX2
-RUN wget -q https://s3.amazonaws.com/plink2-assets/alpha6/plink2_linux_amd_avx2_20260228.zip -O amd.zip \
+RUN wget -q https://s3.amazonaws.com/plink2-assets/alpha7/plink2_linux_amd_avx2_20260808.zip -O amd.zip \
     && unzip -q amd.zip -d /tmp/amd \
     && mv /tmp/amd/plink2 /usr/local/bin/variants/plink2_amd_avx2 \
     && rm -rf amd.zip /tmp/amd
 
 # Generic x86_64
-RUN wget -q https://s3.amazonaws.com/plink2-assets/alpha6/plink2_linux_x86_64_20260228.zip -O generic.zip \
+RUN wget -q https://s3.amazonaws.com/plink2-assets/alpha7/plink2_linux_x86_64_20260808.zip -O generic.zip \
     && unzip -q generic.zip -d /tmp/generic \
     && mv /tmp/generic/plink2 /usr/local/bin/variants/plink2_generic \
     && rm -rf generic.zip /tmp/generic


### PR DESCRIPTION
# Purpose

Current plink2 version (alpha6, build 20260228) seg faults at the start of the chrX Hardy-Weinberg pass on large cohorts. see [here](https://batch.hail.populationgenomics.org.au/batches/1135770/jobs/13) for an example. The plink2 changelog for the 8 Aug 2026 build (alpha 7.3) fixes --hardy / chrX --hwe misbehaviour on biobank-scale data.

## Proposed Changes

- Update the three plink2 download URLs from alpha6/20260228 to alpha7/20260808 (all verified to exist).
- Bump the image VERSION to 1.9-20250819-PLINK-2.0-20260808. PLINK 1.9 is unchanged.

Changelog reference: https://www.cog-genomics.org/plink/2.0/