### PR TITLE
MultiQC v1.34

### DIFF
--- a/images/multiqc/Dockerfile
+++ b/images/multiqc/Dockerfile
@@ -1,5 +1,5 @@
-FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2 AS base
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg2-1 AS base
 
-ARG VERSION=${VERSION:-1.33}
+ARG VERSION=${VERSION:-1.34}
 
 RUN pip install multiqc==${VERSION}


### PR DESCRIPTION
Build of MultiQC [v1.34](https://github.com/MultiQC/MultiQC/releases/tag/v1.34)

Also updates the base image to the latest `cpg_hail_gcloud` (with hail v0.2.138)

Once built and deployed to the artifact repo, will push another PR to build v1.35 (latest)