### PR TITLE
Add PLINK2_FORCE_VARIANT override to the plink wrapper

### DIFF
--- a/images/plink/scripts/plink_wrapper.sh
+++ b/images/plink/scripts/plink_wrapper.sh
@@ -7,8 +7,19 @@
 BASE=$(basename "$0")
 CMD="$1"
 
-# Select the best PLINK2 binary variant based on host CPU features
+# Select the best PLINK2 binary variant based on host CPU features.
+# PLINK2_FORCE_VARIANT overrides detection (generic | intel_avx2 | amd_avx2) —
+# e.g. to sidestep AVX2-build-specific bugs such as the a.7.3 chrX --hwe hang.
 select_plink2_binary() {
+    if [ -n "$PLINK2_FORCE_VARIANT" ]; then
+        FORCED="/usr/local/bin/variants/plink2_$PLINK2_FORCE_VARIANT"
+        if [ ! -x "$FORCED" ]; then
+            echo "PLINK2_FORCE_VARIANT=$PLINK2_FORCE_VARIANT: $FORCED not found" >&2
+            exit 1
+        fi
+        echo "$FORCED"
+        return
+    fi
     BINARY="/usr/local/bin/variants/plink2_generic"
     if [ -f /proc/cpuinfo ]; then
         # Check for AVX2 support


### PR DESCRIPTION
# Purpose

plink2 a.7.3 AVX2 builds hang in an infinite loop computing chrX Hardy-Weinberg p-values on the OurDNA 2660-sample genotyping-array aggregate (the a.6.33 AVX2 build segfaulted at the same point). The generic x86_64 build of the same version completes the same command on the same data in seconds. Pipelines need a way to pin the binary variant without changing the image's default CPU detection.

## Proposed Changes

- `plink_wrapper.sh`: honour `PLINK2_FORCE_VARIANT` (`generic` | `intel_avx2` | `amd_avx2`) ahead of /proc/cpuinfo detection. Unset means behaviour is unchanged. An unknown value fails loudly.
- Suggest deploying as tag `1.9-20250819-PLINK-2.0-20260808-2`.

The popgen-genotyping HWE job will set `PLINK2_FORCE_VARIANT=generic` until the upstream AVX2 bug is fixed. Upstream report to plink2 is being raised separately.